### PR TITLE
feat: TaposFiller TTL cache, with_tapos(), and unit tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3453,6 +3453,7 @@ dependencies = [
  "alloy-sol-types",
  "hex",
  "thiserror 2.0.18",
+ "tokio",
  "tronz-primitives",
  "tronz-provider",
  "tronz-sol-macro",

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -31,4 +31,7 @@ provider = [
 ]
 
 [dev-dependencies]
-hex = { workspace = true }
+hex            = { workspace = true }
+alloy-primitives = { workspace = true }
+tokio          = { workspace = true }
+tronz-provider = { workspace = true, features = ["mock"] }

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -146,3 +146,39 @@ impl ContractError {
         Self::Abi(error)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn dummy_err() -> alloy_dyn_abi::Error {
+        alloy_dyn_abi::Error::TypeMismatch {
+            expected: "uint256".into(),
+            actual: "bytes".into(),
+        }
+    }
+
+    #[test]
+    fn empty_data_yields_zero_data() {
+        let err = ContractError::decode_err("balanceOf", &[], dummy_err());
+        assert!(
+            matches!(&err, ContractError::ZeroData(name, _) if name == "balanceOf"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn full_signature_is_stripped_to_name() {
+        let err = ContractError::decode_err("transfer(address,uint256)", &[], dummy_err());
+        assert!(
+            matches!(&err, ContractError::ZeroData(name, _) if name == "transfer"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn non_empty_data_yields_abi_error() {
+        let err = ContractError::decode_err("balanceOf", &[0xde, 0xad], dummy_err());
+        assert!(matches!(err, ContractError::Abi(_)), "got {err:?}");
+    }
+}

--- a/crates/contract/src/event_filter.rs
+++ b/crates/contract/src/event_filter.rs
@@ -90,3 +90,91 @@ impl<P: TronProvider, E: SolEvent> TronEventFilter<P, E> {
             .collect()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_sol_types::sol;
+    use tronz_provider::{RootProvider, transport::mock::MockTransport};
+
+    use super::*;
+
+    sol! {
+        // Transfer(address indexed from, address indexed to, uint256 value)
+        event Transfer(address indexed from, address indexed to, uint256 value);
+    }
+
+    fn addr(b: u8) -> Address {
+        Address::from_evm_bytes({
+            let mut a = [0u8; 20];
+            a[19] = b;
+            a
+        })
+    }
+
+    fn make_filter(
+        address: Option<Address>,
+    ) -> TronEventFilter<RootProvider<MockTransport>, Transfer> {
+        TronEventFilter::new(RootProvider::new(MockTransport::new()), address)
+    }
+
+    // Constructs a valid Transfer log: from/to are indexed (topics), value is data.
+    fn transfer_log(contract: Address, from: Address, to: Address, value: u64) -> Log {
+        let mut t1 = [0u8; 32];
+        t1[12..].copy_from_slice(from.as_evm_bytes());
+        let mut t2 = [0u8; 32];
+        t2[12..].copy_from_slice(to.as_evm_bytes());
+        let mut data = [0u8; 32];
+        data[24..].copy_from_slice(&value.to_be_bytes());
+        Log::new(
+            contract,
+            vec![Transfer::SIGNATURE_HASH, B256::from(t1), B256::from(t2)],
+            data.to_vec(),
+        )
+    }
+
+    #[test]
+    fn no_address_filter_accepts_any_emitter() {
+        let filter = make_filter(None);
+        let logs = vec![
+            transfer_log(addr(1), addr(10), addr(11), 1),
+            transfer_log(addr(2), addr(10), addr(11), 2),
+        ];
+        assert_eq!(filter.decode_logs(&logs).len(), 2);
+    }
+
+    #[test]
+    fn address_filter_rejects_wrong_emitter() {
+        let contract = addr(1);
+        let filter = make_filter(Some(contract));
+        let logs = vec![
+            transfer_log(contract, addr(10), addr(11), 100),
+            transfer_log(addr(2), addr(10), addr(11), 200),
+        ];
+        let events = filter.decode_logs(&logs);
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].value, alloy_primitives::U256::from(100u64));
+    }
+
+    #[test]
+    fn wrong_topic0_is_skipped() {
+        let filter = make_filter(None);
+        let mut log = transfer_log(addr(1), addr(2), addr(3), 42);
+        log.topics[0] = B256::ZERO;
+        assert!(filter.decode_logs(&[log]).is_empty());
+    }
+
+    #[test]
+    fn no_topics_is_skipped() {
+        let filter = make_filter(None);
+        let log = Log::new(addr(1), vec![], vec![]);
+        assert!(filter.decode_logs(&[log]).is_empty());
+    }
+
+    #[test]
+    fn missing_indexed_topic_silently_skipped() {
+        // topic0 matches but from/to topics are absent — decode_raw_log fails.
+        let filter = make_filter(None);
+        let log = Log::new(addr(1), vec![Transfer::SIGNATURE_HASH], [0u8; 32].to_vec());
+        assert!(filter.decode_logs(&[log]).is_empty());
+    }
+}

--- a/crates/contract/src/sol_call.rs
+++ b/crates/contract/src/sol_call.rs
@@ -79,3 +79,74 @@ impl<P: TronProvider, C: SolCall> TronCallBuilder<P, C> {
         self.inner.send().await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use alloy_primitives::U256;
+    use alloy_sol_types::sol;
+    use tronz_primitives::{Address, Bytes};
+    use tronz_provider::{RootProvider, transport::mock::MockTransport, types::ConstantCallResult};
+
+    use super::*;
+    use crate::{call::CallBuilder, error::ContractError};
+
+    sol! {
+        function balanceOf(address) external view returns (uint256);
+    }
+
+    fn addr() -> Address {
+        Address::from_evm_bytes([1u8; 20])
+    }
+
+    fn make_builder(
+        provider: RootProvider<MockTransport>,
+    ) -> TronCallBuilder<RootProvider<MockTransport>, balanceOfCall> {
+        TronCallBuilder::new(CallBuilder::new(provider, addr(), Bytes::new()))
+    }
+
+    fn canned(output: Vec<u8>) -> ConstantCallResult {
+        ConstantCallResult {
+            output,
+            energy_used: 0,
+            revert_reason: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_output_yields_zero_data_error() {
+        let provider = RootProvider::new(MockTransport::new());
+        provider
+            .transport()
+            .push_ok("trigger_constant_contract", canned(vec![]));
+        let err = make_builder(provider).call().await.unwrap_err();
+        assert!(
+            matches!(&err, ContractError::ZeroData(name, _) if name == "balanceOf"),
+            "expected ZeroData(\"balanceOf\", _), got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn valid_output_decodes_correctly() {
+        let provider = RootProvider::new(MockTransport::new());
+        let mut out = [0u8; 32];
+        out[31] = 99;
+        provider
+            .transport()
+            .push_ok("trigger_constant_contract", canned(out.to_vec()));
+        let value = make_builder(provider).call().await.unwrap();
+        assert_eq!(value, U256::from(99u64));
+    }
+
+    #[tokio::test]
+    async fn truncated_output_yields_abi_error() {
+        let provider = RootProvider::new(MockTransport::new());
+        provider
+            .transport()
+            .push_ok("trigger_constant_contract", canned(vec![0xde, 0xad]));
+        let err = make_builder(provider).call().await.unwrap_err();
+        assert!(
+            matches!(err, ContractError::Abi(_)),
+            "expected Abi(_), got {err:?}"
+        );
+    }
+}

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -4,12 +4,19 @@
 //! Modeled on alloy's `TxFiller` / `JoinFill` pattern (see `DESIGN.md` §5.3).
 
 use core::future::Future;
-use std::time::Duration;
+use std::{
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 
 use tronz_primitives::{Address, B256, RecoverableSignature, Trx};
 use tronz_signer::{SignerError, TronSigner};
 
-use crate::{error::Result, provider::TronProvider, types::TransactionRequest};
+use crate::{
+    error::Result,
+    provider::TronProvider,
+    types::{BlockInfo, TransactionRequest},
+};
 
 /// Whether a filler still has work to do for a given request.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -96,23 +103,43 @@ impl<L: TxFiller, R: TxFiller> TxFiller for JoinFill<L, R> {
 
 /// Fills TAPOS fields (`ref_block_*`, `expiration`, `timestamp`) from the
 /// latest block. Required before broadcasting client-built transactions.
-#[derive(Clone, Copy, Debug)]
+///
+/// The most-recently-fetched block is cached for [`block_ttl`] (default 3 s,
+/// matching TRON's block interval) so that bursts of transactions share a
+/// single `get_now_block` round-trip.  All clones of the same filler share
+/// the same cache via an inner [`Arc`].
+///
+/// [`block_ttl`]: TaposFiller::with_block_ttl
+#[derive(Clone, Debug)]
 pub struct TaposFiller {
     expiry: Duration,
+    block_ttl: Duration,
+    cached: Arc<Mutex<Option<(BlockInfo, Instant)>>>,
 }
 
 impl TaposFiller {
-    /// Default 5-minute expiry. TRON blocks arrive every ~3 s, so 60 s (the
-    /// previous default) was too tight under moderate network congestion.
+    /// Default 5-minute expiry and 3-second block cache TTL.
     pub fn new() -> Self {
         Self {
             expiry: Duration::from_secs(300),
+            block_ttl: Duration::from_secs(3),
+            cached: Arc::new(Mutex::new(None)),
         }
     }
 
-    /// Override the expiry window.
+    /// Override the transaction expiry window.
     pub fn with_expiry(expiry: Duration) -> Self {
-        Self { expiry }
+        Self {
+            expiry,
+            ..Self::new()
+        }
+    }
+
+    /// Override how long a fetched block is reused before the next
+    /// `get_now_block` call.  Set to `Duration::ZERO` to disable caching.
+    pub fn with_block_ttl(mut self, ttl: Duration) -> Self {
+        self.block_ttl = ttl;
+        self
     }
 }
 
@@ -137,19 +164,37 @@ impl TxFiller for TaposFiller {
         provider: &impl TronProvider,
     ) -> impl Future<Output = Result<TransactionRequest>> + Send {
         let expiry = self.expiry;
+        let block_ttl = self.block_ttl;
+        let cached = Arc::clone(&self.cached);
         async move {
             // Skip if TAPOS was already filled server-side (e.g. trigger calls).
             if tx.ref_block_bytes.is_some() {
                 return Ok(tx);
             }
+
+            // Return the cached block if it is still fresh.  The lock is held
+            // only while reading the Option — never across an await point.
+            let cached_block = cached
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(|(b, t)| (t.elapsed() < block_ttl).then(|| b.clone()));
+
+            let block = match cached_block {
+                Some(b) => b,
+                None => {
+                    let b = provider.get_now_block().await?;
+                    *cached.lock().unwrap() = Some((b.clone(), Instant::now()));
+                    b
+                }
+            };
+
             let mut tx = tx;
-            let block = provider.get_now_block().await?;
             tx.ref_block_bytes = Some(block.ref_block_bytes());
             tx.ref_block_hash = Some(block.ref_block_hash());
             // Use the block's own timestamp as the baseline so that clock skew
             // between the client and the node cannot produce an already-expired
-            // transaction (mirrors alloy's approach: chain state from provider,
-            // not from SystemTime).
+            // transaction.
             let base_ms = block.timestamp;
             tx.timestamp = Some(base_ms);
             tx.expiration = Some(base_ms + expiry.as_secs() as i64 * 1_000);
@@ -304,5 +349,166 @@ impl<L: HasSigner + Clone + Send, R: HasSigner + Clone + Send> HasSigner for Joi
                 left.sign(hash).await
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tronz_primitives::B256;
+
+    use super::*;
+    use crate::{
+        provider::RootProvider,
+        transport::mock::MockTransport,
+        types::{BlockInfo, ContractType, TransferContract, TriggerSmartContract},
+    };
+
+    fn addr(b: u8) -> Address {
+        Address::from_evm_bytes({
+            let mut a = [0u8; 20];
+            a[19] = b;
+            a
+        })
+    }
+
+    fn block(num: i64, ts: i64) -> BlockInfo {
+        BlockInfo {
+            number: num,
+            hash: B256::ZERO,
+            timestamp: ts,
+        }
+    }
+
+    fn mock_provider() -> RootProvider<MockTransport> {
+        RootProvider::new(MockTransport::new())
+    }
+
+    // ── TaposFiller ──────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn tapos_filler_fills_from_block() {
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
+
+        let filler = TaposFiller::new();
+        let tx = TransactionRequest::default();
+        assert_eq!(filler.status(&tx), FillerStatus::NeedsWork);
+
+        let filled = filler.fill(tx, &provider).await.unwrap();
+        assert_eq!(filled.ref_block_bytes, Some([0x66, 0x77]));
+        assert_eq!(filled.timestamp, Some(1_000_000));
+        assert_eq!(filled.expiration, Some(1_000_000 + 300_000)); // default 300 s
+    }
+
+    #[tokio::test]
+    async fn tapos_filler_skips_already_filled() {
+        // No response queued — if fill() called get_now_block, MockTransport would panic.
+        let provider = mock_provider();
+
+        let filler = TaposFiller::new();
+        let mut tx = TransactionRequest::default();
+        tx.ref_block_bytes = Some([0xaa, 0xbb]);
+        assert_eq!(filler.status(&tx), FillerStatus::Ready);
+
+        let filled = filler.fill(tx, &provider).await.unwrap();
+        assert_eq!(filled.ref_block_bytes, Some([0xaa, 0xbb]));
+    }
+
+    #[tokio::test]
+    async fn tapos_filler_reuses_cached_block() {
+        let provider = mock_provider();
+        // Only one response queued — second fill() must hit the cache.
+        provider
+            .transport()
+            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 2_000_000));
+
+        let filler = TaposFiller::new(); // default TTL = 3 s
+        let filled1 = filler
+            .fill(TransactionRequest::default(), &provider)
+            .await
+            .unwrap();
+        // Second call: MockTransport would panic if it tried to pop a second response.
+        let filled2 = filler
+            .fill(TransactionRequest::default(), &provider)
+            .await
+            .unwrap();
+
+        assert_eq!(filled1.ref_block_bytes, filled2.ref_block_bytes);
+        assert_eq!(filled1.timestamp, filled2.timestamp);
+    }
+
+    #[tokio::test]
+    async fn tapos_filler_cache_shared_across_clones() {
+        let provider = mock_provider();
+        // One response — the clone must share the cache and not re-fetch.
+        provider
+            .transport()
+            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 3_000_000));
+
+        let filler = TaposFiller::new();
+        let clone = filler.clone();
+        filler
+            .fill(TransactionRequest::default(), &provider)
+            .await
+            .unwrap();
+        // Clone shares the Arc — no second push_ok needed.
+        clone
+            .fill(TransactionRequest::default(), &provider)
+            .await
+            .unwrap();
+    }
+
+    // ── FeeLimitFiller ───────────────────────────────────────────────────────
+
+    #[test]
+    fn fee_limit_filler_sets_limit_for_trigger() {
+        let limit = Trx::from_sun_unchecked(10_000_000);
+        let filler = FeeLimitFiller::new(limit);
+        let mut tx = TransactionRequest::default().with_contract(
+            ContractType::TriggerSmartContract(TriggerSmartContract {
+                owner_address: addr(1),
+                contract_address: addr(2),
+                call_value: Trx::ZERO,
+                data: Default::default(),
+                call_token_value: Trx::ZERO,
+                token_id: 0,
+            }),
+        );
+        assert!(tx.fee_limit.is_none());
+        filler.fill_sync(&mut tx);
+        assert_eq!(tx.fee_limit, Some(limit));
+    }
+
+    #[test]
+    fn fee_limit_filler_skips_when_already_set() {
+        let existing = Trx::from_sun_unchecked(5_000_000);
+        let filler = FeeLimitFiller::new(Trx::from_sun_unchecked(10_000_000));
+        let mut tx = TransactionRequest::default()
+            .with_contract(ContractType::TriggerSmartContract(TriggerSmartContract {
+                owner_address: addr(1),
+                contract_address: addr(2),
+                call_value: Trx::ZERO,
+                data: Default::default(),
+                call_token_value: Trx::ZERO,
+                token_id: 0,
+            }))
+            .with_fee_limit(existing);
+        filler.fill_sync(&mut tx);
+        assert_eq!(tx.fee_limit, Some(existing));
+    }
+
+    #[test]
+    fn fee_limit_filler_skips_non_contract_tx() {
+        let filler = FeeLimitFiller::new(Trx::from_sun_unchecked(10_000_000));
+        let mut tx =
+            TransactionRequest::default().with_contract(ContractType::Transfer(TransferContract {
+                owner_address: addr(1),
+                to_address: addr(2),
+                amount: Trx::from_sun_unchecked(1),
+            }));
+        filler.fill_sync(&mut tx);
+        assert!(tx.fee_limit.is_none());
     }
 }

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -408,8 +408,10 @@ mod tests {
         let provider = mock_provider();
 
         let filler = TaposFiller::new();
-        let mut tx = TransactionRequest::default();
-        tx.ref_block_bytes = Some([0xaa, 0xbb]);
+        let tx = TransactionRequest {
+            ref_block_bytes: Some([0xaa, 0xbb]),
+            ..Default::default()
+        };
         assert_eq!(filler.status(&tx), FillerStatus::Ready);
 
         let filled = filler.fill(tx, &provider).await.unwrap();

--- a/crates/provider/src/types/receipt.rs
+++ b/crates/provider/src/types/receipt.rs
@@ -80,6 +80,17 @@ pub struct Log {
     pub data: Bytes,
 }
 
+impl Log {
+    /// Construct a log from its three fields.
+    pub fn new(address: Address, topics: Vec<B256>, data: impl Into<Bytes>) -> Self {
+        Self {
+            address,
+            topics,
+            data: data.into(),
+        }
+    }
+}
+
 /// Resource usage receipt for a transaction.
 #[derive(Clone, Debug, Default)]
 #[non_exhaustive]

--- a/crates/provider/src/types/transaction.rs
+++ b/crates/provider/src/types/transaction.rs
@@ -1,8 +1,10 @@
 //! Transaction request / raw / signed types.
 
+use std::time::Duration;
+
 use tronz_primitives::{RecoverableSignature, Trx, TxId};
 
-use crate::types::contract::ContractType;
+use crate::types::{BlockInfo, contract::ContractType};
 
 /// Builder-stage transaction: all fields optional, filled progressively by
 /// fillers before being finalized into a [`RawTransaction`].
@@ -55,6 +57,22 @@ impl TransactionRequest {
     /// Set the permission id for multisig transactions.
     pub fn with_permission_id(mut self, id: i32) -> Self {
         self.permission_id = Some(id);
+        self
+    }
+
+    /// Fill TAPOS fields directly from a known block, bypassing [`TaposFiller`].
+    ///
+    /// Use this when the caller already has a [`BlockInfo`] in hand — for
+    /// example, an indexer that fetched the block to process it — so that no
+    /// additional `get_now_block` network call is needed.  [`TaposFiller`] will
+    /// detect that the fields are already set and skip its own fetch.
+    ///
+    /// [`TaposFiller`]: crate::fillers::TaposFiller
+    pub fn with_tapos(mut self, block: &BlockInfo, expiry: Duration) -> Self {
+        self.ref_block_bytes = Some(block.ref_block_bytes());
+        self.ref_block_hash = Some(block.ref_block_hash());
+        self.timestamp = Some(block.timestamp);
+        self.expiration = Some(block.timestamp + expiry.as_millis() as i64);
         self
     }
 }


### PR DESCRIPTION
- feat: TaposFiller 3s TTL block cache — concurrent transactions share a single get_now_block round-trip
- feat: TransactionRequest.with_tapos() for indexers to inject a known block directly, bypassing the filler
- test: TaposFiller / FeeLimitFiller / TronCallBuilder / TronEventFilter / ContractError

Related to #16