### PR TITLE
feat: add unit tests for provider builders, fillers, and extension APIs

### DIFF
--- a/crates/provider/src/builders/freeze.rs
+++ b/crates/provider/src/builders/freeze.rs
@@ -256,3 +256,62 @@ impl<'a, P: TronProvider> UnfreezeBuilder<'a, P> {
         self.provider.send_transaction(req).await
     }
 }
+
+#[cfg(test)]
+mod freeze_builder_tests {
+    use tronz_primitives::Address;
+
+    use super::*;
+    use crate::{provider::RootProvider, transport::mock::MockTransport};
+
+    fn addr(b: u8) -> Address {
+        Address::from_evm_bytes({
+            let mut a = [0u8; 20];
+            a[19] = b;
+            a
+        })
+    }
+
+    fn mock_provider() -> RootProvider<MockTransport> {
+        RootProvider::new(MockTransport::new())
+    }
+
+    #[tokio::test]
+    async fn freeze_missing_amount_returns_error() {
+        let provider = mock_provider();
+        let err = provider
+            .freeze_balance()
+            .from(addr(1))
+            .send()
+            .await
+            .err()
+            .unwrap();
+        assert!(err.is_local_usage_error());
+    }
+
+    #[tokio::test]
+    async fn freeze_v1_missing_amount_returns_error() {
+        let provider = mock_provider();
+        let err = provider
+            .freeze_balance_v1()
+            .from(addr(1))
+            .send()
+            .await
+            .err()
+            .unwrap();
+        assert!(err.is_local_usage_error());
+    }
+
+    #[tokio::test]
+    async fn unfreeze_missing_amount_returns_error() {
+        let provider = mock_provider();
+        let err = provider
+            .unfreeze_balance()
+            .from(addr(1))
+            .send()
+            .await
+            .err()
+            .unwrap();
+        assert!(err.is_local_usage_error());
+    }
+}

--- a/crates/provider/src/builders/transfer.rs
+++ b/crates/provider/src/builders/transfer.rs
@@ -72,3 +72,51 @@ impl<'a, P: TronProvider> TransferBuilder<'a, P> {
         self.provider.send_transaction(req).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tronz_primitives::Address;
+
+    use super::*;
+    use crate::{provider::RootProvider, transport::mock::MockTransport};
+
+    fn addr(b: u8) -> Address {
+        Address::from_evm_bytes({
+            let mut a = [0u8; 20];
+            a[19] = b;
+            a
+        })
+    }
+
+    fn mock_provider() -> RootProvider<MockTransport> {
+        RootProvider::new(MockTransport::new())
+    }
+
+    #[tokio::test]
+    async fn missing_to_returns_error() {
+        let provider = mock_provider();
+        let err = provider
+            .send_trx()
+            .from(addr(1))
+            .amount(Trx::from_sun(1_000_000).unwrap())
+            .send()
+            .await
+            .err()
+            .unwrap();
+        assert!(err.is_local_usage_error());
+    }
+
+    #[tokio::test]
+    async fn missing_amount_returns_error() {
+        let provider = mock_provider();
+        let err = provider
+            .send_trx()
+            .from(addr(1))
+            .to(addr(2))
+            .send()
+            .await
+            .err()
+            .unwrap();
+        assert!(err.is_local_usage_error());
+    }
+}

--- a/crates/provider/src/error.rs
+++ b/crates/provider/src/error.rs
@@ -290,3 +290,90 @@ pub type Result<T, E = ProviderError> = core::result::Result<T, E>;
 
 /// Result alias for the raw transport layer.
 pub type TransportResult<T> = core::result::Result<T, TransportErrorKind>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── TransportErrorKind helpers ────────────────────────────────────────────
+
+    #[test]
+    fn retryable_grpc_codes() {
+        use tonic::Code;
+        for code in [Code::Unavailable, Code::ResourceExhausted, Code::Aborted] {
+            let err = TransportErrorKind::Grpc(tonic::Status::new(code, ""));
+            assert!(err.is_retryable(), "{code:?} should be retryable");
+            assert!(err.is_grpc());
+        }
+    }
+
+    #[test]
+    fn non_retryable_grpc_codes() {
+        use tonic::Code;
+        for code in [
+            Code::DeadlineExceeded,
+            Code::NotFound,
+            Code::InvalidArgument,
+        ] {
+            let err = TransportErrorKind::Grpc(tonic::Status::new(code, ""));
+            assert!(!err.is_retryable(), "{code:?} should not be retryable");
+        }
+    }
+
+    #[test]
+    fn malformed_helpers() {
+        let err = TransportErrorKind::malformed("bad payload");
+        assert!(!err.is_retryable());
+        assert!(err.is_malformed());
+        assert_eq!(err.as_malformed(), Some("bad payload"));
+    }
+
+    #[test]
+    fn node_error_helpers() {
+        let err = TransportErrorKind::NodeError("contract failed".into());
+        assert!(!err.is_retryable());
+        assert!(err.is_node_error());
+        assert_eq!(err.as_node_error(), Some("contract failed"));
+    }
+
+    #[test]
+    fn non_retryable_helpers() {
+        let err = TransportErrorKind::non_retryable_str("fatal");
+        assert!(!err.is_retryable());
+        assert!(err.is_non_retryable());
+    }
+
+    // ── RpcError / ProviderError helpers ─────────────────────────────────────
+
+    #[test]
+    fn node_error_promoted_from_transport_kind() {
+        let transport_err = TransportErrorKind::NodeError("contract failed".into());
+        let rpc_err: ProviderError = transport_err.into();
+        assert!(rpc_err.is_node_error());
+        assert!(!rpc_err.is_transport_error());
+        assert_eq!(rpc_err.as_node_error(), Some("contract failed"));
+    }
+
+    #[test]
+    fn transport_error_wraps_non_node_kinds() {
+        let transport_err = TransportErrorKind::malformed("bad");
+        let rpc_err: ProviderError = transport_err.into();
+        assert!(rpc_err.is_transport_error());
+        assert!(!rpc_err.is_node_error());
+    }
+
+    #[test]
+    fn rpc_is_retryable_delegates_to_transport() {
+        let err =
+            ProviderError::Transport(TransportErrorKind::Grpc(tonic::Status::unavailable("down")));
+        assert!(err.is_retryable());
+    }
+
+    #[test]
+    fn local_usage_error_is_not_retryable() {
+        let err = ProviderError::missing_field("to");
+        assert!(err.is_local_usage_error());
+        assert!(!err.is_transport_error());
+        assert!(!err.is_retryable());
+    }
+}

--- a/crates/provider/src/ext/exchange.rs
+++ b/crates/provider/src/ext/exchange.rs
@@ -458,3 +458,59 @@ impl<'a, P: TronProvider> ExchangeTradeBuilder<'a, P> {
         self.provider.send_transaction(req).await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use tronz_primitives::Address;
+
+    use super::*;
+    use crate::{provider::RootProvider, transport::mock::MockTransport, types::ExchangeInfo};
+
+    fn mock_provider() -> RootProvider<MockTransport> {
+        RootProvider::new(MockTransport::new())
+    }
+
+    fn exchange(id: i64) -> ExchangeInfo {
+        ExchangeInfo {
+            exchange_id: id,
+            creator_address: Address::from_evm_bytes([0u8; 20]),
+            create_time: 0,
+            first_token_id: "_".into(),
+            first_token_balance: 1_000_000,
+            second_token_id: "1000001".into(),
+            second_token_balance: 500_000,
+        }
+    }
+
+    #[tokio::test]
+    async fn list_exchanges_returns_pushed_list() {
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok::<Vec<ExchangeInfo>>("list_exchanges", vec![exchange(1), exchange(2)]);
+        let result = provider.list_exchanges().await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].exchange_id, 1);
+        assert_eq!(result[1].exchange_id, 2);
+    }
+
+    #[tokio::test]
+    async fn get_exchange_by_id_found() {
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok::<Option<ExchangeInfo>>("get_exchange_by_id", Some(exchange(7)));
+        let result = provider.get_exchange_by_id(7).await.unwrap();
+        assert_eq!(result.unwrap().exchange_id, 7);
+    }
+
+    #[tokio::test]
+    async fn get_exchange_by_id_not_found() {
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok::<Option<ExchangeInfo>>("get_exchange_by_id", None);
+        let result = provider.get_exchange_by_id(99).await.unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/provider/src/ext/market.rs
+++ b/crates/provider/src/ext/market.rs
@@ -281,3 +281,74 @@ impl<'a, P: TronProvider> MarketCancelBuilder<'a, P> {
         self.provider.send_transaction(req).await
     }
 }
+#[cfg(test)]
+mod tests {
+    use tronz_primitives::Address;
+
+    use super::*;
+    use crate::{
+        provider::RootProvider,
+        transport::mock::MockTransport,
+        types::{MarketOrderInfo, MarketOrderPair, MarketOrderState},
+    };
+
+    fn mock_provider() -> RootProvider<MockTransport> {
+        RootProvider::new(MockTransport::new())
+    }
+
+    fn addr(b: u8) -> Address {
+        Address::from_evm_bytes({
+            let mut a = [0u8; 20];
+            a[19] = b;
+            a
+        })
+    }
+
+    fn order(owner: Address) -> MarketOrderInfo {
+        MarketOrderInfo {
+            order_id: vec![0u8; 32],
+            owner_address: owner,
+            create_time: 0,
+            sell_token_id: "_".into(),
+            sell_token_quantity: 1_000_000,
+            buy_token_id: "1000001".into(),
+            buy_token_quantity: 500_000,
+            sell_token_quantity_remain: 1_000_000,
+            sell_token_quantity_return: 0,
+            state: MarketOrderState::Active,
+        }
+    }
+
+    #[tokio::test]
+    async fn get_market_pair_list_returns_pushed_pairs() {
+        let provider = mock_provider();
+        let pairs = vec![
+            MarketOrderPair {
+                sell_token_id: "_".into(),
+                buy_token_id: "1000001".into(),
+            },
+            MarketOrderPair {
+                sell_token_id: "1000001".into(),
+                buy_token_id: "_".into(),
+            },
+        ];
+        provider
+            .transport()
+            .push_ok::<Vec<MarketOrderPair>>("get_market_pair_list", pairs);
+        let result = provider.get_market_pair_list().await.unwrap();
+        assert_eq!(result.len(), 2);
+        assert_eq!(result[0].sell_token_id, "_");
+    }
+
+    #[tokio::test]
+    async fn get_market_order_by_account_returns_orders() {
+        let owner = addr(1);
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok::<Vec<MarketOrderInfo>>("get_market_order_by_account", vec![order(owner)]);
+        let result = provider.get_market_order_by_account(owner).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].owner_address, owner);
+    }
+}

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -513,4 +513,64 @@ mod tests {
         filler.fill_sync(&mut tx);
         assert!(tx.fee_limit.is_none());
     }
+
+    // ── SignerFiller ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn signer_filler_exposes_address() {
+        use tronz_signer::LocalSigner;
+        let signer = LocalSigner::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap();
+        let expected = signer.address();
+        let filler = SignerFiller::new(signer);
+        assert_eq!(filler.signer_address(), Some(expected));
+        assert_eq!(filler.signer().address(), expected);
+    }
+
+    // ── JoinFill ─────────────────────────────────────────────────────────────
+
+    #[test]
+    fn join_fill_prefers_right_signer() {
+        use tronz_signer::LocalSigner;
+        let signer = LocalSigner::from_hex(
+            "0000000000000000000000000000000000000000000000000000000000000001",
+        )
+        .unwrap();
+        let expected = signer.address();
+        // left = TaposFiller (no signer), right = SignerFiller
+        let join = JoinFill::new(TaposFiller::new(), SignerFiller::new(signer));
+        assert_eq!(join.signer_address(), Some(expected));
+    }
+
+    #[test]
+    fn join_fill_no_signer_when_both_none() {
+        let join = JoinFill::new(TaposFiller::new(), FeeLimitFiller::new(Trx::ZERO));
+        assert_eq!(join.signer_address(), None);
+    }
+
+    #[tokio::test]
+    async fn join_fill_runs_tapos_and_fee_limit() {
+        let provider = mock_provider();
+        provider
+            .transport()
+            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
+
+        let limit = Trx::from_sun_unchecked(10_000_000);
+        let join = JoinFill::new(TaposFiller::new(), FeeLimitFiller::new(limit));
+        let tx = TransactionRequest::default().with_contract(ContractType::TriggerSmartContract(
+            TriggerSmartContract {
+                owner_address: addr(1),
+                contract_address: addr(2),
+                call_value: Trx::ZERO,
+                data: Default::default(),
+                call_token_value: Trx::ZERO,
+                token_id: 0,
+            },
+        ));
+        let filled = join.fill(tx, &provider).await.unwrap();
+        assert_eq!(filled.ref_block_bytes, Some([0x66, 0x77]));
+        assert_eq!(filled.fee_limit, Some(limit));
+    }
 }


### PR DESCRIPTION
- TransferBuilder / FreezeBuilder / FreezeV1Builder / UnfreezeBuilder: missing required fields return local_usage_error
- SignerFiller / JoinFill: signer address exposure and fill delegation
- ExchangeApi / MarketApi / error helpers: mock-based round-trip tests covering list, get, retryability, and promotion

Relates to #16