### PR TITLE
chore: align rustfmt config with alloy and use tracing macros

### DIFF
--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -87,10 +87,7 @@ impl<P: TronProvider> CallBuilder<P> {
             call_token_value: self.call_token_value,
             token_id: self.token_id,
         };
-        self.provider
-            .estimate_energy(params)
-            .await
-            .map_err(ContractError::Provider)
+        self.provider.estimate_energy(params).await.map_err(ContractError::Provider)
     }
 
     /// Execute as a **constant call** (`trigger_constant_contract`).

--- a/crates/contract/src/deploy.rs
+++ b/crates/contract/src/deploy.rs
@@ -21,19 +21,10 @@
 //! #     abi: &[u8],
 //! # ) -> tronz_contract::Result<()> {
 //! // One-shot: broadcast + wait + return address
-//! let address = provider
-//!     .deploy(bytecode.clone())
-//!     .abi(abi)
-//!     .name("MyToken")
-//!     .deploy()
-//!     .await?;
+//! let address = provider.deploy(bytecode.clone()).abi(abi).name("MyToken").deploy().await?;
 //!
 //! // Or split into broadcast + poll separately:
-//! let pending = provider
-//!     .deploy(bytecode)
-//!     .abi(abi)
-//!     .send()
-//!     .await?;
+//! let pending = provider.deploy(bytecode).abi(abi).send().await?;
 //! let info = pending.get_receipt().await?;
 //! let contract_address = info.contract_address;
 //! # Ok(()) }
@@ -142,8 +133,7 @@ impl<P: TronProvider> DeployBuilder<P> {
         // Transport errors → ContractError::Provider,
         // timeout → ContractError::ConfirmationTimeout.
         let info = pending.get_receipt().await?;
-        info.contract_address
-            .ok_or(ContractError::ContractNotDeployed)
+        info.contract_address.ok_or(ContractError::ContractNotDeployed)
     }
 
     /// Build, sign, and broadcast the deployment transaction.
@@ -176,9 +166,6 @@ impl<P: TronProvider> DeployBuilder<P> {
             req = req.with_fee_limit(limit);
         }
 
-        self.provider
-            .send_transaction(req)
-            .await
-            .map_err(ContractError::Provider)
+        self.provider.send_transaction(req).await.map_err(ContractError::Provider)
     }
 }

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -85,9 +85,9 @@ impl From<PendingTransactionError> for ContractError {
             // Forward any future variants added to PendingTransactionError as a
             // LocalUsageError so this From impl doesn't need updating on every
             // minor version of tronz-provider.
-            _ => Self::Provider(ProviderError::local_usage_str(
-                "unknown pending transaction error",
-            )),
+            _ => {
+                Self::Provider(ProviderError::local_usage_str("unknown pending transaction error"))
+            }
         }
     }
 }
@@ -97,11 +97,7 @@ impl ContractError {
     ///
     /// [`Revert`]: ContractError::Revert
     pub fn as_revert_data(&self) -> Option<&Bytes> {
-        if let Self::Revert(data) = self {
-            Some(data)
-        } else {
-            None
-        }
+        if let Self::Revert(data) = self { Some(data) } else { None }
     }
 
     /// Attempt to ABI-decode the revert data into a specific [`SolError`] type.
@@ -121,16 +117,14 @@ impl ContractError {
     /// # }
     /// ```
     pub fn as_decoded_error<E: SolError>(&self) -> Option<E> {
-        self.as_revert_data()
-            .and_then(|data| E::abi_decode(data).ok())
+        self.as_revert_data().and_then(|data| E::abi_decode(data).ok())
     }
 
     /// Attempt to ABI-decode the revert data into one of the custom errors in a [`SolInterface`].
     ///
     /// Returns `None` if the error is not a revert, or if decoding fails.
     pub fn as_decoded_interface_error<I: SolInterface>(&self) -> Option<I> {
-        self.as_revert_data()
-            .and_then(|data| I::abi_decode(data).ok())
+        self.as_revert_data().and_then(|data| I::abi_decode(data).ok())
     }
 
     /// Build a [`ContractError`] from a failed output decode.
@@ -152,10 +146,7 @@ mod tests {
     use super::*;
 
     fn dummy_err() -> alloy_dyn_abi::Error {
-        alloy_dyn_abi::Error::TypeMismatch {
-            expected: "uint256".into(),
-            actual: "bytes".into(),
-        }
+        alloy_dyn_abi::Error::TypeMismatch { expected: "uint256".into(), actual: "bytes".into() }
     }
 
     #[test]

--- a/crates/contract/src/event.rs
+++ b/crates/contract/src/event.rs
@@ -60,9 +60,7 @@ pub fn log_matches<E: SolEvent>(log: &Log) -> bool {
 /// Logs that match but fail to decode yield an `Err`.
 #[cfg(feature = "provider")]
 pub fn decode_logs<'a, E: SolEvent + 'a>(logs: &'a [Log]) -> impl Iterator<Item = Result<E>> + 'a {
-    logs.iter()
-        .filter(|log| log_matches::<E>(log))
-        .map(decode_log::<E>)
+    logs.iter().filter(|log| log_matches::<E>(log)).map(decode_log::<E>)
 }
 
 /// Return all topic-0 hashes present in the log slice (deduplicated).
@@ -71,6 +69,5 @@ pub fn decode_logs<'a, E: SolEvent + 'a>(logs: &'a [Log]) -> impl Iterator<Item 
 #[cfg(feature = "provider")]
 pub fn topic0_set(logs: &[Log]) -> impl Iterator<Item = B256> + '_ {
     let mut seen = std::collections::HashSet::new();
-    logs.iter()
-        .filter_map(move |log| log.topics.first().copied().filter(|t| seen.insert(*t)))
+    logs.iter().filter_map(move |log| log.topics.first().copied().filter(|t| seen.insert(*t)))
 }

--- a/crates/contract/src/event_filter.rs
+++ b/crates/contract/src/event_filter.rs
@@ -35,11 +35,7 @@ pub struct TronEventFilter<P, E> {
 impl<P: TronProvider, E: SolEvent> TronEventFilter<P, E> {
     /// Create a new filter, optionally restricted to a specific contract address.
     pub fn new(provider: P, address: Option<Address>) -> Self {
-        Self {
-            provider,
-            address,
-            _event: PhantomData,
-        }
+        Self { provider, address, _event: PhantomData }
     }
 
     /// Narrow the filter to a specific contract address.
@@ -69,10 +65,7 @@ impl<P: TronProvider, E: SolEvent> TronEventFilter<P, E> {
             .get_transaction_info_by_block_num(block_num)
             .await
             .map_err(ContractError::Provider)?;
-        Ok(infos
-            .iter()
-            .flat_map(|info| self.decode_logs(&info.logs))
-            .collect())
+        Ok(infos.iter().flat_map(|info| self.decode_logs(&info.logs)).collect())
     }
 
     // ── internal ──────────────────────────────────────────────────────────────

--- a/crates/contract/src/instance.rs
+++ b/crates/contract/src/instance.rs
@@ -28,11 +28,7 @@ impl<P> ContractInstance<P> {
     /// Create a contract instance with a dynamic ABI [`Interface`].
     #[inline]
     pub fn new(address: Address, provider: P, interface: Interface) -> Self {
-        Self {
-            address,
-            provider,
-            interface,
-        }
+        Self { address, provider, interface }
     }
 
     /// The contract address.
@@ -84,9 +80,7 @@ impl<P> std::ops::Deref for ContractInstance<P> {
 
 impl<P> std::fmt::Debug for ContractInstance<P> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ContractInstance")
-            .field("address", &self.address)
-            .finish()
+        f.debug_struct("ContractInstance").field("address", &self.address).finish()
     }
 }
 
@@ -98,11 +92,7 @@ impl<P: TronProvider> ContractInstance<P> {
     /// [`Trc20Instance`]: crate::trc20::Trc20Instance
     #[inline]
     pub fn new_raw(provider: P, address: Address) -> Self {
-        Self {
-            address,
-            provider,
-            interface: Interface::empty(),
-        }
+        Self { address, provider, interface: Interface::empty() }
     }
 
     // ── raw calldata ──────────────────────────────────────────────────────────

--- a/crates/contract/src/interface.rs
+++ b/crates/contract/src/interface.rs
@@ -44,11 +44,7 @@ impl Interface {
     pub fn new(abi: JsonAbi) -> Self {
         let functions = build_selector_map(&abi);
         let events = build_event_map(&abi);
-        Self {
-            abi,
-            functions,
-            events,
-        }
+        Self { abi, functions, events }
     }
 
     /// Create an empty interface (no functions, no events).
@@ -82,10 +78,7 @@ impl Interface {
         selector: &Selector,
         args: &[DynSolValue],
     ) -> Result<Bytes> {
-        Ok(self
-            .get_by_selector(selector)?
-            .abi_encode_input(args)?
-            .into())
+        Ok(self.get_by_selector(selector)?.abi_encode_input(args)?.into())
     }
 
     // ── decode input ──────────────────────────────────────────────────────────
@@ -121,8 +114,7 @@ impl Interface {
     ) -> Result<Vec<DynSolValue>> {
         let f = self.get_by_selector(selector)?;
         let name = f.name.as_str();
-        f.abi_decode_output(data)
-            .map_err(|e| ContractError::decode_err(name, data, e))
+        f.abi_decode_output(data).map_err(|e| ContractError::decode_err(name, data, e))
     }
 
     // ── decode log ────────────────────────────────────────────────────────────
@@ -207,10 +199,7 @@ fn build_selector_map(abi: &JsonAbi) -> HashMap<Selector, (String, usize)> {
     abi.functions
         .iter()
         .flat_map(|(name, overloads)| {
-            overloads
-                .iter()
-                .enumerate()
-                .map(move |(idx, f)| (f.selector(), (name.clone(), idx)))
+            overloads.iter().enumerate().map(move |(idx, f)| (f.selector(), (name.clone(), idx)))
         })
         .collect()
 }

--- a/crates/contract/src/sol_call.rs
+++ b/crates/contract/src/sol_call.rs
@@ -34,28 +34,19 @@ impl<P: TronProvider, C: SolCall> TronCallBuilder<P, C> {
     /// Wrap a raw [`CallBuilder`].
     #[inline]
     pub fn new(inner: CallBuilder<P>) -> Self {
-        Self {
-            inner,
-            _call: PhantomData,
-        }
+        Self { inner, _call: PhantomData }
     }
 
     /// Attach a TRX amount to the call (for payable functions).
     #[inline]
     pub fn value(self, trx: Trx) -> Self {
-        Self {
-            inner: self.inner.value(trx),
-            _call: PhantomData,
-        }
+        Self { inner: self.inner.value(trx), _call: PhantomData }
     }
 
     /// Attach a TRC10 token to the call.
     #[inline]
     pub fn token(self, token_id: i64, value: Trx) -> Self {
-        Self {
-            inner: self.inner.token(token_id, value),
-            _call: PhantomData,
-        }
+        Self { inner: self.inner.token(token_id, value), _call: PhantomData }
     }
 
     /// Estimate the energy this call would consume.
@@ -105,19 +96,13 @@ mod tests {
     }
 
     fn canned(output: Vec<u8>) -> ConstantCallResult {
-        ConstantCallResult {
-            output,
-            energy_used: 0,
-            revert_reason: None,
-        }
+        ConstantCallResult { output, energy_used: 0, revert_reason: None }
     }
 
     #[tokio::test]
     async fn empty_output_yields_zero_data_error() {
         let provider = RootProvider::new(MockTransport::new());
-        provider
-            .transport()
-            .push_ok("trigger_constant_contract", canned(vec![]));
+        provider.transport().push_ok("trigger_constant_contract", canned(vec![]));
         let err = make_builder(provider).call().await.unwrap_err();
         assert!(
             matches!(&err, ContractError::ZeroData(name, _) if name == "balanceOf"),
@@ -130,9 +115,7 @@ mod tests {
         let provider = RootProvider::new(MockTransport::new());
         let mut out = [0u8; 32];
         out[31] = 99;
-        provider
-            .transport()
-            .push_ok("trigger_constant_contract", canned(out.to_vec()));
+        provider.transport().push_ok("trigger_constant_contract", canned(out.to_vec()));
         let value = make_builder(provider).call().await.unwrap();
         assert_eq!(value, U256::from(99u64));
     }
@@ -140,13 +123,8 @@ mod tests {
     #[tokio::test]
     async fn truncated_output_yields_abi_error() {
         let provider = RootProvider::new(MockTransport::new());
-        provider
-            .transport()
-            .push_ok("trigger_constant_contract", canned(vec![0xde, 0xad]));
+        provider.transport().push_ok("trigger_constant_contract", canned(vec![0xde, 0xad]));
         let err = make_builder(provider).call().await.unwrap_err();
-        assert!(
-            matches!(err, ContractError::Abi(_)),
-            "expected Abi(_), got {err:?}"
-        );
+        assert!(matches!(err, ContractError::Abi(_)), "expected Abi(_), got {err:?}");
     }
 }

--- a/crates/contract/src/trc20/instance.rs
+++ b/crates/contract/src/trc20/instance.rs
@@ -40,9 +40,7 @@ pub struct Trc20Instance<P: TronProvider> {
 impl<P: TronProvider> Trc20Instance<P> {
     /// Bind to the TRC20 contract at `address`.
     pub fn new(provider: P, address: Address) -> Self {
-        Self {
-            inner: ContractInstance::new_raw(provider, address),
-        }
+        Self { inner: ContractInstance::new_raw(provider, address) }
     }
 
     /// The contract address.
@@ -57,70 +55,45 @@ impl<P: TronProvider> Trc20Instance<P> {
 
     /// Return a new instance pointing at a different address.
     pub fn at(self, address: Address) -> Self {
-        Self {
-            inner: self.inner.at(address),
-        }
+        Self { inner: self.inner.at(address) }
     }
 
     // ── reads ─────────────────────────────────────────────────────────────────
 
     /// Fetch the token name (e.g. `"Tether USD"`).
     pub async fn name(&self) -> Result<String, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC20::nameCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out = self.inner.call_raw(ITRC20::nameCall {}.abi_encode().into()).call().await?;
         Ok(decode_string_return(&out)?)
     }
 
     /// Fetch the token symbol (e.g. `"USDT"`).
     pub async fn symbol(&self) -> Result<String, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC20::symbolCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out = self.inner.call_raw(ITRC20::symbolCall {}.abi_encode().into()).call().await?;
         Ok(decode_string_return(&out)?)
     }
 
     /// Fetch the number of decimal places.
     pub async fn decimals(&self) -> Result<u8, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC20::decimalsCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out = self.inner.call_raw(ITRC20::decimalsCall {}.abi_encode().into()).call().await?;
         Ok(decode_decimals_return(&out)?)
     }
 
     /// Fetch the total token supply.
     pub async fn total_supply(&self) -> Result<U256, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC20::totalSupplyCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out =
+            self.inner.call_raw(ITRC20::totalSupplyCall {}.abi_encode().into()).call().await?;
         Ok(decode_uint256_return(&out)?)
     }
 
     /// Fetch the token balance of `account`.
     pub async fn balance_of(&self, account: Address) -> Result<U256, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(encode_balance_of(account))
-            .call()
-            .await?;
+        let out = self.inner.call_raw(encode_balance_of(account)).call().await?;
         Ok(decode_uint256_return(&out)?)
     }
 
     /// Fetch the remaining allowance that `spender` may transfer on behalf of `owner`.
     pub async fn allowance(&self, owner: Address, spender: Address) -> Result<U256, Trc20Error> {
-        let out = self
-            .inner
-            .call_raw(encode_allowance(owner, spender))
-            .call()
-            .await?;
+        let out = self.inner.call_raw(encode_allowance(owner, spender)).call().await?;
         Ok(decode_uint256_return(&out)?)
     }
 
@@ -132,10 +105,7 @@ impl<P: TronProvider> Trc20Instance<P> {
         to: Address,
         amount: U256,
     ) -> Result<PendingTransaction<P>, Trc20Error> {
-        self.inner
-            .call_raw(encode_transfer(to, amount))
-            .send()
-            .await
+        self.inner.call_raw(encode_transfer(to, amount)).send().await
     }
 
     /// Approve `spender` to transfer up to `amount` on the signer's behalf.
@@ -144,10 +114,7 @@ impl<P: TronProvider> Trc20Instance<P> {
         spender: Address,
         amount: U256,
     ) -> Result<PendingTransaction<P>, Trc20Error> {
-        self.inner
-            .call_raw(encode_approve(spender, amount))
-            .send()
-            .await
+        self.inner.call_raw(encode_approve(spender, amount)).send().await
     }
 
     /// Transfer `amount` tokens from `from` to `to`, using the signer's allowance.
@@ -157,10 +124,7 @@ impl<P: TronProvider> Trc20Instance<P> {
         to: Address,
         amount: U256,
     ) -> Result<PendingTransaction<P>, Trc20Error> {
-        self.inner
-            .call_raw(encode_transfer_from(from, to, amount))
-            .send()
-            .await
+        self.inner.call_raw(encode_transfer_from(from, to, amount)).send().await
     }
 }
 

--- a/crates/contract/src/trc20/mod.rs
+++ b/crates/contract/src/trc20/mod.rs
@@ -34,52 +34,27 @@ sol! {
 /// ABI-encode the `transfer(to, amount)` call into the calldata bytes used by a
 /// `TriggerSmartContract`.
 pub fn encode_transfer(to: Address, amount: U256) -> Bytes {
-    ITRC20::transferCall {
-        to: to.into(),
-        amount,
-    }
-    .abi_encode()
-    .into()
+    ITRC20::transferCall { to: to.into(), amount }.abi_encode().into()
 }
 
 /// ABI-encode the `approve(spender, amount)` call.
 pub fn encode_approve(spender: Address, amount: U256) -> Bytes {
-    ITRC20::approveCall {
-        spender: spender.into(),
-        amount,
-    }
-    .abi_encode()
-    .into()
+    ITRC20::approveCall { spender: spender.into(), amount }.abi_encode().into()
 }
 
 /// ABI-encode the `transferFrom(from, to, amount)` call.
 pub fn encode_transfer_from(from: Address, to: Address, amount: U256) -> Bytes {
-    ITRC20::transferFromCall {
-        from: from.into(),
-        to: to.into(),
-        amount,
-    }
-    .abi_encode()
-    .into()
+    ITRC20::transferFromCall { from: from.into(), to: to.into(), amount }.abi_encode().into()
 }
 
 /// ABI-encode the `balanceOf(account)` constant call.
 pub fn encode_balance_of(account: Address) -> Bytes {
-    ITRC20::balanceOfCall {
-        account: account.into(),
-    }
-    .abi_encode()
-    .into()
+    ITRC20::balanceOfCall { account: account.into() }.abi_encode().into()
 }
 
 /// ABI-encode the `allowance(owner, spender)` constant call.
 pub fn encode_allowance(owner: Address, spender: Address) -> Bytes {
-    ITRC20::allowanceCall {
-        owner: owner.into(),
-        spender: spender.into(),
-    }
-    .abi_encode()
-    .into()
+    ITRC20::allowanceCall { owner: owner.into(), spender: spender.into() }.abi_encode().into()
 }
 
 /// Decode the `uint256` returned by `balanceOf` / `allowance` / `totalSupply`.

--- a/crates/contract/src/trc721/instance.rs
+++ b/crates/contract/src/trc721/instance.rs
@@ -38,9 +38,7 @@ pub struct Trc721Instance<P: TronProvider> {
 impl<P: TronProvider> Trc721Instance<P> {
     /// Bind to the TRC721 contract at `address`.
     pub fn new(provider: P, address: Address) -> Self {
-        Self {
-            inner: ContractInstance::new_raw(provider, address),
-        }
+        Self { inner: ContractInstance::new_raw(provider, address) }
     }
 
     /// The contract address.
@@ -55,30 +53,20 @@ impl<P: TronProvider> Trc721Instance<P> {
 
     /// Return a new instance pointing at a different address.
     pub fn at(self, address: Address) -> Self {
-        Self {
-            inner: self.inner.at(address),
-        }
+        Self { inner: self.inner.at(address) }
     }
 
     // ── reads ─────────────────────────────────────────────────────────────────
 
     /// Fetch the token name.
     pub async fn name(&self) -> Result<String, Trc721Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC721::nameCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out = self.inner.call_raw(ITRC721::nameCall {}.abi_encode().into()).call().await?;
         Ok(decode_string_return(&out)?)
     }
 
     /// Fetch the token symbol.
     pub async fn symbol(&self) -> Result<String, Trc721Error> {
-        let out = self
-            .inner
-            .call_raw(ITRC721::symbolCall {}.abi_encode().into())
-            .call()
-            .await?;
+        let out = self.inner.call_raw(ITRC721::symbolCall {}.abi_encode().into()).call().await?;
         Ok(decode_string_return(&out)?)
     }
 
@@ -86,11 +74,7 @@ impl<P: TronProvider> Trc721Instance<P> {
     pub async fn token_uri(&self, token_id: U256) -> Result<String, Trc721Error> {
         let out = self
             .inner
-            .call_raw(
-                ITRC721::tokenURICall { tokenId: token_id }
-                    .abi_encode()
-                    .into(),
-            )
+            .call_raw(ITRC721::tokenURICall { tokenId: token_id }.abi_encode().into())
             .call()
             .await?;
         Ok(decode_string_return(&out)?)
@@ -104,11 +88,7 @@ impl<P: TronProvider> Trc721Instance<P> {
 
     /// Fetch the owner of `token_id`.
     pub async fn owner_of(&self, token_id: U256) -> Result<Address, Trc721Error> {
-        let out = self
-            .inner
-            .call_raw(encode_owner_of(token_id))
-            .call()
-            .await?;
+        let out = self.inner.call_raw(encode_owner_of(token_id)).call().await?;
         Ok(decode_address_return(&out)?)
     }
 
@@ -116,11 +96,7 @@ impl<P: TronProvider> Trc721Instance<P> {
     pub async fn get_approved(&self, token_id: U256) -> Result<Address, Trc721Error> {
         let out = self
             .inner
-            .call_raw(
-                ITRC721::getApprovedCall { tokenId: token_id }
-                    .abi_encode()
-                    .into(),
-            )
+            .call_raw(ITRC721::getApprovedCall { tokenId: token_id }.abi_encode().into())
             .call()
             .await?;
         Ok(decode_address_return(&out)?)
@@ -135,12 +111,9 @@ impl<P: TronProvider> Trc721Instance<P> {
         let out = self
             .inner
             .call_raw(
-                ITRC721::isApprovedForAllCall {
-                    owner: owner.into(),
-                    operator: operator.into(),
-                }
-                .abi_encode()
-                .into(),
+                ITRC721::isApprovedForAllCall { owner: owner.into(), operator: operator.into() }
+                    .abi_encode()
+                    .into(),
             )
             .call()
             .await?;
@@ -156,10 +129,7 @@ impl<P: TronProvider> Trc721Instance<P> {
         to: Address,
         token_id: U256,
     ) -> Result<PendingTransaction<P>, Trc721Error> {
-        self.inner
-            .call_raw(encode_transfer_from(from, to, token_id))
-            .send()
-            .await
+        self.inner.call_raw(encode_transfer_from(from, to, token_id)).send().await
     }
 
     /// Safe-transfer `token_id` from `from` to `to` (calls `onERC721Received` on the recipient).
@@ -169,10 +139,7 @@ impl<P: TronProvider> Trc721Instance<P> {
         to: Address,
         token_id: U256,
     ) -> Result<PendingTransaction<P>, Trc721Error> {
-        self.inner
-            .call_raw(encode_safe_transfer_from(from, to, token_id))
-            .send()
-            .await
+        self.inner.call_raw(encode_safe_transfer_from(from, to, token_id)).send().await
     }
 
     /// Approve `to` to transfer `token_id`.
@@ -181,10 +148,7 @@ impl<P: TronProvider> Trc721Instance<P> {
         to: Address,
         token_id: U256,
     ) -> Result<PendingTransaction<P>, Trc721Error> {
-        self.inner
-            .call_raw(encode_approve(to, token_id))
-            .send()
-            .await
+        self.inner.call_raw(encode_approve(to, token_id)).send().await
     }
 
     /// Approve or revoke `operator` to manage all of the signer's tokens.
@@ -195,12 +159,9 @@ impl<P: TronProvider> Trc721Instance<P> {
     ) -> Result<PendingTransaction<P>, Trc721Error> {
         self.inner
             .call_raw(
-                ITRC721::setApprovalForAllCall {
-                    operator: operator.into(),
-                    approved,
-                }
-                .abi_encode()
-                .into(),
+                ITRC721::setApprovalForAllCall { operator: operator.into(), approved }
+                    .abi_encode()
+                    .into(),
             )
             .send()
             .await

--- a/crates/contract/src/trc721/mod.rs
+++ b/crates/contract/src/trc721/mod.rs
@@ -41,54 +41,35 @@ sol! {
 /// ABI-encode the `transferFrom(from, to, tokenId)` call.
 pub fn encode_transfer_from(from: Address, to: Address, token_id: U256) -> Bytes {
     use alloy_sol_types::SolCall as _;
-    ITRC721::transferFromCall {
-        from: from.into(),
-        to: to.into(),
-        tokenId: token_id,
-    }
-    .abi_encode()
-    .into()
+    ITRC721::transferFromCall { from: from.into(), to: to.into(), tokenId: token_id }
+        .abi_encode()
+        .into()
 }
 
 /// ABI-encode the `safeTransferFrom(from, to, tokenId)` call (no data).
 pub fn encode_safe_transfer_from(from: Address, to: Address, token_id: U256) -> Bytes {
     use alloy_sol_types::SolCall as _;
-    ITRC721::safeTransferFrom_0Call {
-        from: from.into(),
-        to: to.into(),
-        tokenId: token_id,
-    }
-    .abi_encode()
-    .into()
+    ITRC721::safeTransferFrom_0Call { from: from.into(), to: to.into(), tokenId: token_id }
+        .abi_encode()
+        .into()
 }
 
 /// ABI-encode the `approve(to, tokenId)` call.
 pub fn encode_approve(to: Address, token_id: U256) -> Bytes {
     use alloy_sol_types::SolCall as _;
-    ITRC721::approveCall {
-        to: to.into(),
-        tokenId: token_id,
-    }
-    .abi_encode()
-    .into()
+    ITRC721::approveCall { to: to.into(), tokenId: token_id }.abi_encode().into()
 }
 
 /// ABI-encode the `balanceOf(owner)` constant call.
 pub fn encode_balance_of(owner: Address) -> Bytes {
     use alloy_sol_types::SolCall as _;
-    ITRC721::balanceOfCall {
-        owner: owner.into(),
-    }
-    .abi_encode()
-    .into()
+    ITRC721::balanceOfCall { owner: owner.into() }.abi_encode().into()
 }
 
 /// ABI-encode the `ownerOf(tokenId)` constant call.
 pub fn encode_owner_of(token_id: U256) -> Bytes {
     use alloy_sol_types::SolCall as _;
-    ITRC721::ownerOfCall { tokenId: token_id }
-        .abi_encode()
-        .into()
+    ITRC721::ownerOfCall { tokenId: token_id }.abi_encode().into()
 }
 
 /// Decode the `uint256` returned by `balanceOf`.
@@ -128,19 +109,13 @@ mod tests {
     #[test]
     fn transfer_from_selector() {
         // keccak256("transferFrom(address,address,uint256)")[..4] == 0x23b872dd
-        assert_eq!(
-            ITRC721::transferFromCall::SELECTOR,
-            [0x23, 0xb8, 0x72, 0xdd]
-        );
+        assert_eq!(ITRC721::transferFromCall::SELECTOR, [0x23, 0xb8, 0x72, 0xdd]);
     }
 
     #[test]
     fn safe_transfer_from_selector() {
         // keccak256("safeTransferFrom(address,address,uint256)")[..4] == 0x42842e0e
-        assert_eq!(
-            ITRC721::safeTransferFrom_0Call::SELECTOR,
-            [0x42, 0x84, 0x2e, 0x0e]
-        );
+        assert_eq!(ITRC721::safeTransferFrom_0Call::SELECTOR, [0x42, 0x84, 0x2e, 0x0e]);
     }
 
     #[test]

--- a/crates/contract/tests/sol_macro.rs
+++ b/crates/contract/tests/sol_macro.rs
@@ -24,9 +24,7 @@ tron_sol! {
 #[test]
 fn type_layer_encoding() {
     let owner: Address = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t".parse().unwrap();
-    let call = IERC20::balanceOfCall {
-        owner: owner.into(),
-    };
+    let call = IERC20::balanceOfCall { owner: owner.into() };
     let encoded = call.abi_encode();
     assert_eq!(&encoded[..4], &IERC20::balanceOfCall::SELECTOR);
     assert_eq!(encoded.len(), 36);
@@ -36,10 +34,7 @@ fn type_layer_encoding() {
 fn return_type_decode() {
     let mut out = [0u8; 32];
     out[31] = 42;
-    assert_eq!(
-        IERC20::balanceOfCall::abi_decode_returns(&out).unwrap(),
-        U256::from(42u64),
-    );
+    assert_eq!(IERC20::balanceOfCall::abi_decode_returns(&out).unwrap(), U256::from(42u64),);
 }
 
 #[allow(dead_code, clippy::unused_async)]
@@ -57,10 +52,7 @@ async fn _erc20_api<P: TronProvider + Clone>(provider: P, addr: Address) {
     let _ = token.address();
     let _ = token.clone().at(addr);
     // generic entry point
-    let _ = token
-        .call_builder(&IERC20::balanceOfCall { owner: addr.into() })
-        .call()
-        .await;
+    let _ = token.call_builder(&IERC20::balanceOfCall { owner: addr.into() }).call().await;
 }
 
 #[allow(dead_code)]
@@ -94,10 +86,7 @@ async fn _erc721_api<P: TronProvider + Clone>(provider: P, addr: Address) {
     let nft = IERC721::new(addr, provider);
     let _ = nft.ownerOf(U256::ZERO).call().await;
     let _ = nft.safeTransferFrom_0(addr, addr, U256::ZERO).send().await;
-    let _ = nft
-        .safeTransferFrom_1(addr, addr, U256::ZERO, Bytes::new())
-        .send()
-        .await;
+    let _ = nft.safeTransferFrom_1(addr, addr, U256::ZERO, Bytes::new()).send().await;
 }
 
 // user-defined value types (UDVT)
@@ -153,10 +142,7 @@ fn bytecode_is_embedded() {
 
 #[test]
 fn deployed_bytecode_is_embedded() {
-    assert_eq!(
-        &SimpleToken::DEPLOYED_BYTECODE[..],
-        &[0x60, 0x80, 0x60, 0x40, 0x51]
-    );
+    assert_eq!(&SimpleToken::DEPLOYED_BYTECODE[..], &[0x60, 0x80, 0x60, 0x40, 0x51]);
 }
 
 #[allow(dead_code, clippy::unused_async)]
@@ -227,10 +213,7 @@ tron_sol! {
 fn multiple_items_one_invocation() {
     // bare struct/enum from the same block are usable as types
     let owner: Address = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t".parse().unwrap();
-    let _order = Order {
-        maker: owner.into(),
-        amount: U256::from(7u64),
-    };
+    let _order = Order { maker: owner.into(), amount: U256::from(7u64) };
     let _side = Side::Buy;
     // both interfaces produced their own selectors + instances
     let _ = IExchange::placeCall::SELECTOR;
@@ -240,16 +223,8 @@ fn multiple_items_one_invocation() {
 #[allow(dead_code, clippy::unused_async)]
 async fn _multi_instance_api<P: TronProvider + Clone>(provider: P, addr: Address) {
     let exchange = IExchange::new(addr, provider.clone());
-    let _ = exchange
-        .place(
-            Order {
-                maker: addr.into(),
-                amount: U256::ZERO,
-            },
-            Side::Sell,
-        )
-        .call()
-        .await;
+    let _ =
+        exchange.place(Order { maker: addr.into(), amount: U256::ZERO }, Side::Sell).call().await;
     let registry = IRegistry::new(addr, provider);
     let _ = registry.lookup(U256::ZERO).call().await;
 }
@@ -277,20 +252,12 @@ tron_sol! {
 fn attributes_pass_through() {
     // `#[derive(Debug, Default, PartialEq)]` was forwarded to the type layer
     let a = Point::default();
-    let b = Point {
-        x: Default::default(),
-        y: Default::default(),
-    };
+    let b = Point { x: Default::default(), y: Default::default() };
     assert_eq!(a, b);
     // `Debug` is available because the derive was forwarded
     let _ = format!("{a:?}");
     // the call struct also derives Debug (from the `#[derive(Debug)]` on the interface)
-    let _ = format!(
-        "{:?}",
-        IPoints::setCall {
-            p: Point::default()
-        }
-    );
+    let _ = format!("{:?}", IPoints::setCall { p: Point::default() });
 }
 
 // public state variables → getter methods

--- a/crates/primitives/src/address.rs
+++ b/crates/primitives/src/address.rs
@@ -36,10 +36,9 @@ impl Address {
 
     /// Construct from a 21-byte slice, validating length and prefix.
     pub fn from_slice(slice: &[u8]) -> Result<Self, AddressError> {
-        let bytes: [u8; ADDRESS_LEN] = slice.try_into().map_err(|_| AddressError::BadLength {
-            expected: ADDRESS_LEN,
-            got: slice.len(),
-        })?;
+        let bytes: [u8; ADDRESS_LEN] = slice
+            .try_into()
+            .map_err(|_| AddressError::BadLength { expected: ADDRESS_LEN, got: slice.len() })?;
         Self::from_bytes(bytes)
     }
 
@@ -86,9 +85,7 @@ impl Address {
     /// The 20-byte EVM-style body (prefix stripped). Use this when bridging to
     /// `alloy` / ABI encoding.
     pub fn as_evm_bytes(&self) -> &[u8; EVM_ADDRESS_LEN] {
-        self.0[1..]
-            .try_into()
-            .expect("address body is always 20 bytes")
+        self.0[1..].try_into().expect("address body is always 20 bytes")
     }
 
     /// Encode as a base58check (`T...`) string.
@@ -124,11 +121,7 @@ impl FromStr for Address {
         let hexish = s.strip_prefix("0x").unwrap_or(s);
         let looks_hex =
             hexish.len() == ADDRESS_LEN * 2 && hexish.bytes().all(|b| b.is_ascii_hexdigit());
-        if looks_hex {
-            Self::from_hex(s)
-        } else {
-            Self::from_base58(s)
-        }
+        if looks_hex { Self::from_hex(s) } else { Self::from_base58(s) }
     }
 }
 
@@ -195,10 +188,7 @@ mod tests {
     fn bad_prefix_rejected() {
         let mut bytes = [0u8; ADDRESS_LEN];
         bytes[0] = 0x42;
-        assert!(matches!(
-            Address::from_bytes(bytes),
-            Err(AddressError::BadPrefix(0x42))
-        ));
+        assert!(matches!(Address::from_bytes(bytes), Err(AddressError::BadPrefix(0x42))));
     }
 
     #[test]

--- a/crates/primitives/src/signature.rs
+++ b/crates/primitives/src/signature.rs
@@ -29,11 +29,7 @@ impl RecoverableSignature {
         let mut s = [0u8; 32];
         r.copy_from_slice(&bytes[..32]);
         s.copy_from_slice(&bytes[32..]);
-        Self {
-            r,
-            s,
-            v: recovery_id.to_byte(),
-        }
+        Self { r, s, v: recovery_id.to_byte() }
     }
 
     /// Parse the 65-byte `r || s || v` representation.
@@ -94,11 +90,7 @@ impl RecoverableSignature {
 
 impl fmt::Debug for RecoverableSignature {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "RecoverableSignature(0x{})",
-            hex::encode(self.to_bytes())
-        )
+        write!(f, "RecoverableSignature(0x{})", hex::encode(self.to_bytes()))
     }
 }
 

--- a/crates/provider/src/builders/account.rs
+++ b/crates/provider/src/builders/account.rs
@@ -24,12 +24,7 @@ pub struct CreateAccountBuilder<'a, P> {
 
 impl<'a, P: TronProvider> CreateAccountBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            account_address: None,
-            memo: None,
-        }
+        Self { provider, owner: None, account_address: None, memo: None }
     }
 
     /// Override the payer address (defaults to the provider's signer).
@@ -53,9 +48,8 @@ impl<'a, P: TronProvider> CreateAccountBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let account_address = self
-            .account_address
-            .ok_or(Error::missing_field("account_address"))?;
+        let account_address =
+            self.account_address.ok_or(Error::missing_field("account_address"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::CreateAccount(CreateAccountContract {
@@ -83,12 +77,7 @@ pub struct UpdateAccountBuilder<'a, P> {
 
 impl<'a, P: TronProvider> UpdateAccountBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            name: None,
-            memo: None,
-        }
+        Self { provider, owner: None, name: None, memo: None }
     }
 
     /// Override the account address (defaults to the provider's signer).

--- a/crates/provider/src/builders/contract.rs
+++ b/crates/provider/src/builders/contract.rs
@@ -27,12 +27,7 @@ pub struct SetAccountIdBuilder<'a, P> {
 
 impl<'a, P: TronProvider> SetAccountIdBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            account_id: None,
-            memo: None,
-        }
+        Self { provider, owner: None, account_id: None, memo: None }
     }
 
     /// Override the account address (defaults to the provider's signer).
@@ -85,12 +80,7 @@ pub struct ClearContractAbiBuilder<'a, P> {
 
 impl<'a, P: TronProvider> ClearContractAbiBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            contract_address: None,
-            memo: None,
-        }
+        Self { provider, owner: None, contract_address: None, memo: None }
     }
 
     /// Override the contract owner address (defaults to the provider's signer).
@@ -114,9 +104,8 @@ impl<'a, P: TronProvider> ClearContractAbiBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let contract_address = self
-            .contract_address
-            .ok_or(Error::missing_field("contract_address"))?;
+        let contract_address =
+            self.contract_address.ok_or(Error::missing_field("contract_address"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::ClearContractAbi(ClearContractAbiContract {
@@ -182,9 +171,8 @@ impl<'a, P: TronProvider> UpdateContractSettingBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let contract_address = self
-            .contract_address
-            .ok_or(Error::missing_field("contract_address"))?;
+        let contract_address =
+            self.contract_address.ok_or(Error::missing_field("contract_address"))?;
         let consume_user_resource_percent = self
             .consume_user_resource_percent
             .ok_or(Error::missing_field("consume_user_resource_percent"))?;
@@ -254,12 +242,10 @@ impl<'a, P: TronProvider> UpdateContractEnergyLimitBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let contract_address = self
-            .contract_address
-            .ok_or(Error::missing_field("contract_address"))?;
-        let origin_energy_limit = self
-            .origin_energy_limit
-            .ok_or(Error::missing_field("origin_energy_limit"))?;
+        let contract_address =
+            self.contract_address.ok_or(Error::missing_field("contract_address"))?;
+        let origin_energy_limit =
+            self.origin_energy_limit.ok_or(Error::missing_field("origin_energy_limit"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::UpdateEnergyLimit(UpdateEnergyLimitContract {

--- a/crates/provider/src/builders/delegate.rs
+++ b/crates/provider/src/builders/delegate.rs
@@ -96,13 +96,7 @@ pub struct UndelegateBuilder<'a, P> {
 impl<'a, P: TronProvider> UndelegateBuilder<'a, P> {
     /// Start a new undelegate builder (defaults to reclaiming energy).
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            receiver: None,
-            amount: None,
-            resource: ResourceCode::Energy,
-        }
+        Self { provider, owner: None, receiver: None, amount: None, resource: ResourceCode::Energy }
     }
 
     /// Override the delegator account.
@@ -136,14 +130,12 @@ impl<'a, P: TronProvider> UndelegateBuilder<'a, P> {
         let amount = self.amount.ok_or(Error::missing_field("amount"))?;
 
         let req = TransactionRequest {
-            contract: Some(ContractType::UnDelegateResource(
-                UnDelegateResourceContract {
-                    owner_address: owner,
-                    resource: self.resource,
-                    balance: amount,
-                    receiver_address: receiver,
-                },
-            )),
+            contract: Some(ContractType::UnDelegateResource(UnDelegateResourceContract {
+                owner_address: owner,
+                resource: self.resource,
+                balance: amount,
+                receiver_address: receiver,
+            })),
             ..Default::default()
         };
         self.provider.send_transaction(req).await

--- a/crates/provider/src/builders/freeze.rs
+++ b/crates/provider/src/builders/freeze.rs
@@ -107,12 +107,7 @@ pub struct UnfreezeV1Builder<'a, P> {
 impl<'a, P: TronProvider> UnfreezeV1Builder<'a, P> {
     /// Start a new V1 unfreeze builder (defaults to releasing energy stake).
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            resource: ResourceCode::Energy,
-            receiver: None,
-        }
+        Self { provider, owner: None, resource: ResourceCode::Energy, receiver: None }
     }
 
     /// Override the account.
@@ -160,12 +155,7 @@ pub struct FreezeBuilder<'a, P> {
 impl<'a, P: TronProvider> FreezeBuilder<'a, P> {
     /// Start a new freeze builder (defaults to staking for energy).
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            amount: None,
-            resource: ResourceCode::Energy,
-        }
+        Self { provider, owner: None, amount: None, resource: ResourceCode::Energy }
     }
 
     /// Override the staking account.
@@ -214,12 +204,7 @@ pub struct UnfreezeBuilder<'a, P> {
 impl<'a, P: TronProvider> UnfreezeBuilder<'a, P> {
     /// Start a new unfreeze builder (defaults to releasing energy stake).
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            amount: None,
-            resource: ResourceCode::Energy,
-        }
+        Self { provider, owner: None, amount: None, resource: ResourceCode::Energy }
     }
 
     /// Override the account.
@@ -279,39 +264,21 @@ mod freeze_builder_tests {
     #[tokio::test]
     async fn freeze_missing_amount_returns_error() {
         let provider = mock_provider();
-        let err = provider
-            .freeze_balance()
-            .from(addr(1))
-            .send()
-            .await
-            .err()
-            .unwrap();
+        let err = provider.freeze_balance().from(addr(1)).send().await.err().unwrap();
         assert!(err.is_local_usage_error());
     }
 
     #[tokio::test]
     async fn freeze_v1_missing_amount_returns_error() {
         let provider = mock_provider();
-        let err = provider
-            .freeze_balance_v1()
-            .from(addr(1))
-            .send()
-            .await
-            .err()
-            .unwrap();
+        let err = provider.freeze_balance_v1().from(addr(1)).send().await.err().unwrap();
         assert!(err.is_local_usage_error());
     }
 
     #[tokio::test]
     async fn unfreeze_missing_amount_returns_error() {
         let provider = mock_provider();
-        let err = provider
-            .unfreeze_balance()
-            .from(addr(1))
-            .send()
-            .await
-            .err()
-            .unwrap();
+        let err = provider.unfreeze_balance().from(addr(1)).send().await.err().unwrap();
         assert!(err.is_local_usage_error());
     }
 }

--- a/crates/provider/src/builders/mod.rs
+++ b/crates/provider/src/builders/mod.rs
@@ -31,9 +31,7 @@ pub(crate) fn resolve_owner<P: TronProvider>(
     owner: Option<Address>,
     provider: &P,
 ) -> Result<Address> {
-    owner
-        .or_else(|| provider.signer_address())
-        .ok_or(Error::no_signer())
+    owner.or_else(|| provider.signer_address()).ok_or(Error::no_signer())
 }
 
 pub use account::{CreateAccountBuilder, UpdateAccountBuilder};

--- a/crates/provider/src/builders/permission.rs
+++ b/crates/provider/src/builders/permission.rs
@@ -21,13 +21,7 @@ pub struct AccountPermissionUpdateBuilder<'a, P> {
 impl<'a, P: TronProvider> AccountPermissionUpdateBuilder<'a, P> {
     /// Start a new builder.
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            owner_permission: None,
-            witness: None,
-            actives: Vec::new(),
-        }
+        Self { provider, owner: None, owner_permission: None, witness: None, actives: Vec::new() }
     }
 
     /// Override the account being updated.

--- a/crates/provider/src/builders/rewards.rs
+++ b/crates/provider/src/builders/rewards.rs
@@ -20,10 +20,7 @@ pub struct WithdrawBalanceBuilder<'a, P> {
 impl<'a, P: TronProvider> WithdrawBalanceBuilder<'a, P> {
     /// Start a new builder.
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-        }
+        Self { provider, owner: None }
     }
 
     /// Override the account.

--- a/crates/provider/src/builders/transfer.rs
+++ b/crates/provider/src/builders/transfer.rs
@@ -21,13 +21,7 @@ pub struct TransferBuilder<'a, P> {
 impl<'a, P: TronProvider> TransferBuilder<'a, P> {
     /// Start a new transfer builder.
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            to: None,
-            amount: None,
-            memo: None,
-        }
+        Self { provider, owner: None, to: None, amount: None, memo: None }
     }
 
     /// Override the sender (defaults to the provider's signer address).
@@ -109,14 +103,7 @@ mod tests {
     #[tokio::test]
     async fn missing_amount_returns_error() {
         let provider = mock_provider();
-        let err = provider
-            .send_trx()
-            .from(addr(1))
-            .to(addr(2))
-            .send()
-            .await
-            .err()
-            .unwrap();
+        let err = provider.send_trx().from(addr(1)).to(addr(2)).send().await.err().unwrap();
         assert!(err.is_local_usage_error());
     }
 }

--- a/crates/provider/src/builders/vote.rs
+++ b/crates/provider/src/builders/vote.rs
@@ -37,12 +37,7 @@ pub struct VoteBuilder<'a, P> {
 
 impl<'a, P: TronProvider> VoteBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            votes: Vec::new(),
-            memo: None,
-        }
+        Self { provider, owner: None, votes: Vec::new(), memo: None }
     }
 
     /// Override the voter address (defaults to the provider's signer).
@@ -55,20 +50,15 @@ impl<'a, P: TronProvider> VoteBuilder<'a, P> {
     ///
     /// Call multiple times to vote for several SRs in one transaction.
     pub fn vote(mut self, sr_address: Address, count: i64) -> Self {
-        self.votes.push(SrVote {
-            vote_address: sr_address,
-            vote_count: count,
-        });
+        self.votes.push(SrVote { vote_address: sr_address, vote_count: count });
         self
     }
 
     /// Append multiple SR votes at once.
     pub fn votes(mut self, votes: impl IntoIterator<Item = (Address, i64)>) -> Self {
-        self.votes
-            .extend(votes.into_iter().map(|(addr, count)| SrVote {
-                vote_address: addr,
-                vote_count: count,
-            }));
+        self.votes.extend(
+            votes.into_iter().map(|(addr, count)| SrVote { vote_address: addr, vote_count: count }),
+        );
         self
     }
 

--- a/crates/provider/src/builders/withdraw.rs
+++ b/crates/provider/src/builders/withdraw.rs
@@ -21,10 +21,7 @@ pub struct WithdrawExpireBuilder<'a, P> {
 impl<'a, P: TronProvider> WithdrawExpireBuilder<'a, P> {
     /// Start a new builder.
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-        }
+        Self { provider, owner: None }
     }
 
     /// Override the account.
@@ -37,11 +34,9 @@ impl<'a, P: TronProvider> WithdrawExpireBuilder<'a, P> {
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
         let req = TransactionRequest {
-            contract: Some(ContractType::WithdrawExpireUnfreeze(
-                WithdrawExpireUnfreezeContract {
-                    owner_address: owner,
-                },
-            )),
+            contract: Some(ContractType::WithdrawExpireUnfreeze(WithdrawExpireUnfreezeContract {
+                owner_address: owner,
+            })),
             ..Default::default()
         };
         self.provider.send_transaction(req).await
@@ -57,10 +52,7 @@ pub struct CancelAllUnfreezeBuilder<'a, P> {
 impl<'a, P: TronProvider> CancelAllUnfreezeBuilder<'a, P> {
     /// Start a new builder.
     pub fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-        }
+        Self { provider, owner: None }
     }
 
     /// Override the account.
@@ -73,11 +65,9 @@ impl<'a, P: TronProvider> CancelAllUnfreezeBuilder<'a, P> {
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
         let req = TransactionRequest {
-            contract: Some(ContractType::CancelAllUnfreezeV2(
-                CancelAllUnfreezeV2Contract {
-                    owner_address: owner,
-                },
-            )),
+            contract: Some(ContractType::CancelAllUnfreezeV2(CancelAllUnfreezeV2Contract {
+                owner_address: owner,
+            })),
             ..Default::default()
         };
         self.provider.send_transaction(req).await

--- a/crates/provider/src/error.rs
+++ b/crates/provider/src/error.rs
@@ -129,41 +129,25 @@ impl TransportErrorKind {
     /// Returns the message if this is [`NodeError`](Self::NodeError).
     #[inline]
     pub fn as_node_error(&self) -> Option<&str> {
-        if let Self::NodeError(msg) = self {
-            Some(msg)
-        } else {
-            None
-        }
+        if let Self::NodeError(msg) = self { Some(msg) } else { None }
     }
 
     /// Returns the message if this is [`Malformed`](Self::Malformed).
     #[inline]
     pub fn as_malformed(&self) -> Option<&str> {
-        if let Self::Malformed(msg) = self {
-            Some(msg)
-        } else {
-            None
-        }
+        if let Self::Malformed(msg) = self { Some(msg) } else { None }
     }
 
     /// Returns the inner error if this is [`Custom`](Self::Custom).
     #[inline]
     pub const fn as_custom(&self) -> Option<&(dyn StdError + Send + Sync + 'static)> {
-        if let Self::Custom(err) = self {
-            Some(&**err)
-        } else {
-            None
-        }
+        if let Self::Custom(err) = self { Some(&**err) } else { None }
     }
 
     /// Returns the inner error if this is [`NonRetryable`](Self::NonRetryable).
     #[inline]
     pub const fn as_non_retryable(&self) -> Option<&(dyn StdError + Send + Sync + 'static)> {
-        if let Self::NonRetryable(err) = self {
-            Some(&**err)
-        } else {
-            None
-        }
+        if let Self::NonRetryable(err) = self { Some(&**err) } else { None }
     }
 }
 
@@ -252,21 +236,13 @@ impl<E: StdError + 'static> RpcError<E> {
     /// Returns the node-rejection message if this is [`NodeError`](Self::NodeError).
     #[inline]
     pub fn as_node_error(&self) -> Option<&str> {
-        if let Self::NodeError(msg) = self {
-            Some(msg)
-        } else {
-            None
-        }
+        if let Self::NodeError(msg) = self { Some(msg) } else { None }
     }
 
     /// Returns the inner transport error if this is [`Transport`](Self::Transport).
     #[inline]
     pub const fn as_transport_err(&self) -> Option<&E> {
-        if let Self::Transport(e) = self {
-            Some(e)
-        } else {
-            None
-        }
+        if let Self::Transport(e) = self { Some(e) } else { None }
     }
 }
 
@@ -274,8 +250,7 @@ impl RpcError<TransportErrorKind> {
     /// Returns `true` if the underlying transport error is retryable.
     #[inline]
     pub fn is_retryable(&self) -> bool {
-        self.as_transport_err()
-            .is_some_and(TransportErrorKind::is_retryable)
+        self.as_transport_err().is_some_and(TransportErrorKind::is_retryable)
     }
 }
 
@@ -310,11 +285,7 @@ mod tests {
     #[test]
     fn non_retryable_grpc_codes() {
         use tonic::Code;
-        for code in [
-            Code::DeadlineExceeded,
-            Code::NotFound,
-            Code::InvalidArgument,
-        ] {
+        for code in [Code::DeadlineExceeded, Code::NotFound, Code::InvalidArgument] {
             let err = TransportErrorKind::Grpc(tonic::Status::new(code, ""));
             assert!(!err.is_retryable(), "{code:?} should not be retryable");
         }

--- a/crates/provider/src/ext/exchange.rs
+++ b/crates/provider/src/ext/exchange.rs
@@ -74,10 +74,7 @@ pub trait ExchangeApi: TronProvider + Sized {
 
 impl<P: TronProvider> ExchangeApi for P {
     async fn list_exchanges(&self) -> Result<Vec<ExchangeInfo>> {
-        self.transport()
-            .list_exchanges()
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().list_exchanges().await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_paginated_exchange_list(
@@ -92,10 +89,7 @@ impl<P: TronProvider> ExchangeApi for P {
     }
 
     async fn get_exchange_by_id(&self, exchange_id: i64) -> Result<Option<ExchangeInfo>> {
-        self.transport()
-            .get_exchange_by_id(exchange_id)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_exchange_by_id(exchange_id).await.map_err(|e| Error::from(e.into()))
     }
 
     fn exchange_create(&self) -> ExchangeCreateBuilder<'_, Self> {
@@ -182,18 +176,13 @@ impl<'a, P: TronProvider> ExchangeCreateBuilder<'a, P> {
     /// Build, sign, and broadcast the exchange-create transaction.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let first_token_id = self
-            .first_token_id
-            .ok_or(Error::missing_field("first_token_id"))?;
-        let first_token_balance = self
-            .first_token_balance
-            .ok_or(Error::missing_field("first_token_balance"))?;
-        let second_token_id = self
-            .second_token_id
-            .ok_or(Error::missing_field("second_token_id"))?;
-        let second_token_balance = self
-            .second_token_balance
-            .ok_or(Error::missing_field("second_token_balance"))?;
+        let first_token_id = self.first_token_id.ok_or(Error::missing_field("first_token_id"))?;
+        let first_token_balance =
+            self.first_token_balance.ok_or(Error::missing_field("first_token_balance"))?;
+        let second_token_id =
+            self.second_token_id.ok_or(Error::missing_field("second_token_id"))?;
+        let second_token_balance =
+            self.second_token_balance.ok_or(Error::missing_field("second_token_balance"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::ExchangeCreate(ExchangeCreateContract {
@@ -226,14 +215,7 @@ pub struct ExchangeInjectBuilder<'a, P> {
 
 impl<'a, P: TronProvider> ExchangeInjectBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            exchange_id: None,
-            token_id: None,
-            quant: None,
-            memo: None,
-        }
+        Self { provider, owner: None, exchange_id: None, token_id: None, quant: None, memo: None }
     }
 
     /// Override the sender address (defaults to the provider's signer address).
@@ -269,9 +251,7 @@ impl<'a, P: TronProvider> ExchangeInjectBuilder<'a, P> {
     /// Build, sign, and broadcast the inject transaction.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let exchange_id = self
-            .exchange_id
-            .ok_or(Error::missing_field("exchange_id"))?;
+        let exchange_id = self.exchange_id.ok_or(Error::missing_field("exchange_id"))?;
         let token_id = self.token_id.ok_or(Error::missing_field("token_id"))?;
         let quant = self.quant.ok_or(Error::missing_field("quant"))?;
 
@@ -305,14 +285,7 @@ pub struct ExchangeWithdrawBuilder<'a, P> {
 
 impl<'a, P: TronProvider> ExchangeWithdrawBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            exchange_id: None,
-            token_id: None,
-            quant: None,
-            memo: None,
-        }
+        Self { provider, owner: None, exchange_id: None, token_id: None, quant: None, memo: None }
     }
 
     /// Override the sender address (defaults to the provider's signer address).
@@ -348,9 +321,7 @@ impl<'a, P: TronProvider> ExchangeWithdrawBuilder<'a, P> {
     /// Build, sign, and broadcast the withdraw transaction.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let exchange_id = self
-            .exchange_id
-            .ok_or(Error::missing_field("exchange_id"))?;
+        let exchange_id = self.exchange_id.ok_or(Error::missing_field("exchange_id"))?;
         let token_id = self.token_id.ok_or(Error::missing_field("token_id"))?;
         let quant = self.quant.ok_or(Error::missing_field("quant"))?;
 
@@ -435,23 +406,19 @@ impl<'a, P: TronProvider> ExchangeTradeBuilder<'a, P> {
     /// Build, sign, and broadcast the trade transaction.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let exchange_id = self
-            .exchange_id
-            .ok_or(Error::missing_field("exchange_id"))?;
+        let exchange_id = self.exchange_id.ok_or(Error::missing_field("exchange_id"))?;
         let token_id = self.token_id.ok_or(Error::missing_field("token_id"))?;
         let quant = self.quant.ok_or(Error::missing_field("quant"))?;
         let expected = self.expected.ok_or(Error::missing_field("expected"))?;
 
         let req = TransactionRequest {
-            contract: Some(ContractType::ExchangeTransaction(
-                ExchangeTransactionContract {
-                    owner_address: owner,
-                    exchange_id,
-                    token_id,
-                    quant,
-                    expected,
-                },
-            )),
+            contract: Some(ContractType::ExchangeTransaction(ExchangeTransactionContract {
+                owner_address: owner,
+                exchange_id,
+                token_id,
+                quant,
+                expected,
+            })),
             memo: self.memo,
             ..Default::default()
         };
@@ -507,9 +474,7 @@ mod tests {
     #[tokio::test]
     async fn get_exchange_by_id_not_found() {
         let provider = mock_provider();
-        provider
-            .transport()
-            .push_ok::<Option<ExchangeInfo>>("get_exchange_by_id", None);
+        provider.transport().push_ok::<Option<ExchangeInfo>>("get_exchange_by_id", None);
         let result = provider.get_exchange_by_id(99).await.unwrap();
         assert!(result.is_none());
     }

--- a/crates/provider/src/ext/governance.rs
+++ b/crates/provider/src/ext/governance.rs
@@ -69,10 +69,7 @@ pub trait GovernanceApi: TronProvider + Sized {
 
 impl<P: TronProvider> GovernanceApi for P {
     async fn list_proposals(&self) -> Result<Vec<ProposalInfo>> {
-        self.transport()
-            .list_proposals()
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().list_proposals().await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_paginated_proposal_list(
@@ -87,10 +84,7 @@ impl<P: TronProvider> GovernanceApi for P {
     }
 
     async fn get_proposal_by_id(&self, proposal_id: i64) -> Result<ProposalInfo> {
-        self.transport()
-            .get_proposal_by_id(proposal_id)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_proposal_by_id(proposal_id).await.map_err(|e| Error::from(e.into()))
     }
 
     fn submit_proposal(&self) -> SubmitProposalBuilder<'_, Self> {
@@ -120,12 +114,7 @@ pub struct SubmitProposalBuilder<'a, P> {
 
 impl<'a, P: TronProvider> SubmitProposalBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            parameters: HashMap::new(),
-            memo: None,
-        }
+        Self { provider, owner: None, parameters: HashMap::new(), memo: None }
     }
 
     /// Override the proposer address (defaults to the provider's signer).
@@ -188,13 +177,7 @@ pub struct ApproveProposalBuilder<'a, P> {
 
 impl<'a, P: TronProvider> ApproveProposalBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            proposal_id: None,
-            is_add_approval: true,
-            memo: None,
-        }
+        Self { provider, owner: None, proposal_id: None, is_add_approval: true, memo: None }
     }
 
     /// Override the voter address (defaults to the provider's signer).
@@ -226,9 +209,7 @@ impl<'a, P: TronProvider> ApproveProposalBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let proposal_id = self
-            .proposal_id
-            .ok_or(Error::missing_field("proposal_id"))?;
+        let proposal_id = self.proposal_id.ok_or(Error::missing_field("proposal_id"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::ProposalApprove(ProposalApproveContract {
@@ -257,12 +238,7 @@ pub struct CancelProposalBuilder<'a, P> {
 
 impl<'a, P: TronProvider> CancelProposalBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            proposal_id: None,
-            memo: None,
-        }
+        Self { provider, owner: None, proposal_id: None, memo: None }
     }
 
     /// Override the proposer address (defaults to the provider's signer).
@@ -286,9 +262,7 @@ impl<'a, P: TronProvider> CancelProposalBuilder<'a, P> {
     /// Build, sign, and broadcast.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let proposal_id = self
-            .proposal_id
-            .ok_or(Error::missing_field("proposal_id"))?;
+        let proposal_id = self.proposal_id.ok_or(Error::missing_field("proposal_id"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::ProposalDelete(ProposalDeleteContract {

--- a/crates/provider/src/ext/market.rs
+++ b/crates/provider/src/ext/market.rs
@@ -79,10 +79,7 @@ pub trait MarketApi: TronProvider + Sized {
 
 impl<P: TronProvider> MarketApi for P {
     async fn get_market_order_by_id(&self, order_id: &[u8]) -> Result<Option<MarketOrderInfo>> {
-        self.transport()
-            .get_market_order_by_id(order_id)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_market_order_by_id(order_id).await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_market_order_by_account(&self, address: Address) -> Result<Vec<MarketOrderInfo>> {
@@ -115,10 +112,7 @@ impl<P: TronProvider> MarketApi for P {
     }
 
     async fn get_market_pair_list(&self) -> Result<Vec<MarketOrderPair>> {
-        self.transport()
-            .get_market_pair_list()
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_market_pair_list().await.map_err(|e| Error::from(e.into()))
     }
 
     fn market_sell(&self) -> MarketSellBuilder<'_, Self> {
@@ -197,18 +191,12 @@ impl<'a, P: TronProvider> MarketSellBuilder<'a, P> {
     /// Build, sign, and broadcast the sell order.
     pub async fn send(self) -> Result<PendingTransaction<P>> {
         let owner = resolve_owner(self.owner, self.provider)?;
-        let sell_token_id = self
-            .sell_token_id
-            .ok_or(Error::missing_field("sell_token_id"))?;
-        let sell_token_quantity = self
-            .sell_token_quantity
-            .ok_or(Error::missing_field("sell_token_quantity"))?;
-        let buy_token_id = self
-            .buy_token_id
-            .ok_or(Error::missing_field("buy_token_id"))?;
-        let buy_token_quantity = self
-            .buy_token_quantity
-            .ok_or(Error::missing_field("buy_token_quantity"))?;
+        let sell_token_id = self.sell_token_id.ok_or(Error::missing_field("sell_token_id"))?;
+        let sell_token_quantity =
+            self.sell_token_quantity.ok_or(Error::missing_field("sell_token_quantity"))?;
+        let buy_token_id = self.buy_token_id.ok_or(Error::missing_field("buy_token_id"))?;
+        let buy_token_quantity =
+            self.buy_token_quantity.ok_or(Error::missing_field("buy_token_quantity"))?;
 
         let req = TransactionRequest {
             contract: Some(ContractType::MarketSellAsset(MarketSellAssetContract {
@@ -239,12 +227,7 @@ pub struct MarketCancelBuilder<'a, P> {
 
 impl<'a, P: TronProvider> MarketCancelBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            order_id: None,
-            memo: None,
-        }
+        Self { provider, owner: None, order_id: None, memo: None }
     }
 
     /// Override the canceller address (defaults to the provider's signer address).
@@ -323,18 +306,10 @@ mod tests {
     async fn get_market_pair_list_returns_pushed_pairs() {
         let provider = mock_provider();
         let pairs = vec![
-            MarketOrderPair {
-                sell_token_id: "_".into(),
-                buy_token_id: "1000001".into(),
-            },
-            MarketOrderPair {
-                sell_token_id: "1000001".into(),
-                buy_token_id: "_".into(),
-            },
+            MarketOrderPair { sell_token_id: "_".into(), buy_token_id: "1000001".into() },
+            MarketOrderPair { sell_token_id: "1000001".into(), buy_token_id: "_".into() },
         ];
-        provider
-            .transport()
-            .push_ok::<Vec<MarketOrderPair>>("get_market_pair_list", pairs);
+        provider.transport().push_ok::<Vec<MarketOrderPair>>("get_market_pair_list", pairs);
         let result = provider.get_market_pair_list().await.unwrap();
         assert_eq!(result.len(), 2);
         assert_eq!(result[0].sell_token_id, "_");

--- a/crates/provider/src/ext/trc10.rs
+++ b/crates/provider/src/ext/trc10.rs
@@ -129,10 +129,7 @@ pub trait Trc10Api: TronProvider + Sized {
 
 impl<P: TronProvider> Trc10Api for P {
     async fn get_asset_info(&self, token_id: &str) -> Result<Option<AssetInfo>> {
-        self.transport()
-            .get_asset_issue_by_id(token_id)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_asset_issue_by_id(token_id).await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_asset_issue_by_account(&self, address: Address) -> Result<Vec<AssetInfo>> {
@@ -155,17 +152,11 @@ impl<P: TronProvider> Trc10Api for P {
     }
 
     async fn get_asset_issue_by_name(&self, name: &str) -> Result<Option<AssetInfo>> {
-        self.transport()
-            .get_asset_issue_by_name(name)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_asset_issue_by_name(name).await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_asset_issue_list_by_name(&self, name: &str) -> Result<Vec<AssetInfo>> {
-        self.transport()
-            .get_asset_issue_list_by_name(name)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_asset_issue_list_by_name(name).await.map_err(|e| Error::from(e.into()))
     }
 
     fn transfer_trc10(&self) -> TransferTrc10Builder<'_, Self> {
@@ -205,14 +196,7 @@ pub struct TransferTrc10Builder<'a, P> {
 
 impl<'a, P: TronProvider> TransferTrc10Builder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            to: None,
-            token_id: None,
-            amount: None,
-            memo: None,
-        }
+        Self { provider, owner: None, to: None, token_id: None, amount: None, memo: None }
     }
 
     /// Override the sender (defaults to the provider's signer address).
@@ -390,10 +374,7 @@ impl<'a, P: TronProvider> IssueTrc10Builder<'a, P> {
 
     /// Lock a portion of the supply for `days` days.
     pub fn freeze(mut self, amount: i64, days: i64) -> Self {
-        self.frozen_supply.push(FrozenSupply {
-            frozen_amount: amount,
-            frozen_days: days,
-        });
+        self.frozen_supply.push(FrozenSupply { frozen_amount: amount, frozen_days: days });
         self
     }
 
@@ -403,9 +384,7 @@ impl<'a, P: TronProvider> IssueTrc10Builder<'a, P> {
         let name = self.name.ok_or(Error::missing_field("name"))?;
         let abbr = self.abbr.ok_or(Error::missing_field("abbr"))?;
         let url = self.url.ok_or(Error::missing_field("url"))?;
-        let total_supply = self
-            .total_supply
-            .ok_or(Error::missing_field("total_supply"))?;
+        let total_supply = self.total_supply.ok_or(Error::missing_field("total_supply"))?;
 
         let now_ms = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -453,14 +432,7 @@ pub struct ParticipateTrc10Builder<'a, P> {
 
 impl<'a, P: TronProvider> ParticipateTrc10Builder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            to: None,
-            token_id: None,
-            amount: None,
-            memo: None,
-        }
+        Self { provider, owner: None, to: None, token_id: None, amount: None, memo: None }
     }
 
     /// Override the buyer address (defaults to the provider's signer address).
@@ -501,14 +473,12 @@ impl<'a, P: TronProvider> ParticipateTrc10Builder<'a, P> {
         let amount = self.amount.ok_or(Error::missing_field("amount"))?;
 
         let req = TransactionRequest {
-            contract: Some(ContractType::ParticipateAssetIssue(
-                ParticipateAssetIssueContract {
-                    owner_address: owner,
-                    to_address: to,
-                    token_id,
-                    amount,
-                },
-            )),
+            contract: Some(ContractType::ParticipateAssetIssue(ParticipateAssetIssueContract {
+                owner_address: owner,
+                to_address: to,
+                token_id,
+                amount,
+            })),
             memo: self.memo,
             ..Default::default()
         };
@@ -529,11 +499,7 @@ pub struct UnfreezeTrc10Builder<'a, P> {
 
 impl<'a, P: TronProvider> UnfreezeTrc10Builder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            memo: None,
-        }
+        Self { provider, owner: None, memo: None }
     }
 
     /// Override the issuer address (defaults to the provider's signer address).

--- a/crates/provider/src/ext/witness.rs
+++ b/crates/provider/src/ext/witness.rs
@@ -72,17 +72,11 @@ impl<P: TronProvider> WitnessApi for P {
     }
 
     async fn get_brokerage(&self, address: Address) -> Result<u64> {
-        self.transport()
-            .get_brokerage(address)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_brokerage(address).await.map_err(|e| Error::from(e.into()))
     }
 
     async fn get_reward_info(&self, address: Address) -> Result<u64> {
-        self.transport()
-            .get_reward_info(address)
-            .await
-            .map_err(|e| Error::from(e.into()))
+        self.transport().get_reward_info(address).await.map_err(|e| Error::from(e.into()))
     }
 
     fn become_witness(&self) -> BecomeWitnessBuilder<'_, Self> {
@@ -114,12 +108,7 @@ pub struct BecomeWitnessBuilder<'a, P> {
 
 impl<'a, P: TronProvider> BecomeWitnessBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            url: None,
-            memo: None,
-        }
+        Self { provider, owner: None, url: None, memo: None }
     }
 
     /// Override the applicant address (defaults to the provider's signer).
@@ -171,12 +160,7 @@ pub struct UpdateWitnessBuilder<'a, P> {
 
 impl<'a, P: TronProvider> UpdateWitnessBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            update_url: None,
-            memo: None,
-        }
+        Self { provider, owner: None, update_url: None, memo: None }
     }
 
     /// Override the SR address (defaults to the provider's signer).
@@ -228,12 +212,7 @@ pub struct UpdateBrokerageBuilder<'a, P> {
 
 impl<'a, P: TronProvider> UpdateBrokerageBuilder<'a, P> {
     pub(crate) fn new(provider: &'a P) -> Self {
-        Self {
-            provider,
-            owner: None,
-            brokerage: None,
-            memo: None,
-        }
+        Self { provider, owner: None, brokerage: None, memo: None }
     }
 
     /// Override the SR address (defaults to the provider's signer).

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -129,10 +129,7 @@ impl TaposFiller {
 
     /// Override the transaction expiry window.
     pub fn with_expiry(expiry: Duration) -> Self {
-        Self {
-            expiry,
-            ..Self::new()
-        }
+        Self { expiry, ..Self::new() }
     }
 
     /// Override how long a fetched block is reused before the next
@@ -151,11 +148,7 @@ impl Default for TaposFiller {
 
 impl TxFiller for TaposFiller {
     fn status(&self, tx: &TransactionRequest) -> FillerStatus {
-        if tx.ref_block_bytes.is_none() {
-            FillerStatus::NeedsWork
-        } else {
-            FillerStatus::Ready
-        }
+        if tx.ref_block_bytes.is_none() { FillerStatus::NeedsWork } else { FillerStatus::Ready }
     }
 
     fn fill(
@@ -331,9 +324,7 @@ impl<S: TronSigner> HasSigner for SignerFiller<S> {
 
 impl<L: HasSigner + Clone + Send, R: HasSigner + Clone + Send> HasSigner for JoinFill<L, R> {
     fn signer_address(&self) -> Option<Address> {
-        self.right
-            .signer_address()
-            .or_else(|| self.left.signer_address())
+        self.right.signer_address().or_else(|| self.left.signer_address())
     }
 
     fn sign(
@@ -372,11 +363,7 @@ mod tests {
     }
 
     fn block(num: i64, ts: i64) -> BlockInfo {
-        BlockInfo {
-            number: num,
-            hash: B256::ZERO,
-            timestamp: ts,
-        }
+        BlockInfo { number: num, hash: B256::ZERO, timestamp: ts }
     }
 
     fn mock_provider() -> RootProvider<MockTransport> {
@@ -388,9 +375,7 @@ mod tests {
     #[tokio::test]
     async fn tapos_filler_fills_from_block() {
         let provider = mock_provider();
-        provider
-            .transport()
-            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
+        provider.transport().push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
 
         let filler = TaposFiller::new();
         let tx = TransactionRequest::default();
@@ -408,10 +393,7 @@ mod tests {
         let provider = mock_provider();
 
         let filler = TaposFiller::new();
-        let tx = TransactionRequest {
-            ref_block_bytes: Some([0xaa, 0xbb]),
-            ..Default::default()
-        };
+        let tx = TransactionRequest { ref_block_bytes: Some([0xaa, 0xbb]), ..Default::default() };
         assert_eq!(filler.status(&tx), FillerStatus::Ready);
 
         let filled = filler.fill(tx, &provider).await.unwrap();
@@ -422,20 +404,12 @@ mod tests {
     async fn tapos_filler_reuses_cached_block() {
         let provider = mock_provider();
         // Only one response queued — second fill() must hit the cache.
-        provider
-            .transport()
-            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 2_000_000));
+        provider.transport().push_ok("get_now_block", block(0x0011_2233_4455_6677, 2_000_000));
 
         let filler = TaposFiller::new(); // default TTL = 3 s
-        let filled1 = filler
-            .fill(TransactionRequest::default(), &provider)
-            .await
-            .unwrap();
+        let filled1 = filler.fill(TransactionRequest::default(), &provider).await.unwrap();
         // Second call: MockTransport would panic if it tried to pop a second response.
-        let filled2 = filler
-            .fill(TransactionRequest::default(), &provider)
-            .await
-            .unwrap();
+        let filled2 = filler.fill(TransactionRequest::default(), &provider).await.unwrap();
 
         assert_eq!(filled1.ref_block_bytes, filled2.ref_block_bytes);
         assert_eq!(filled1.timestamp, filled2.timestamp);
@@ -445,21 +419,13 @@ mod tests {
     async fn tapos_filler_cache_shared_across_clones() {
         let provider = mock_provider();
         // One response — the clone must share the cache and not re-fetch.
-        provider
-            .transport()
-            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 3_000_000));
+        provider.transport().push_ok("get_now_block", block(0x0011_2233_4455_6677, 3_000_000));
 
         let filler = TaposFiller::new();
         let clone = filler.clone();
-        filler
-            .fill(TransactionRequest::default(), &provider)
-            .await
-            .unwrap();
+        filler.fill(TransactionRequest::default(), &provider).await.unwrap();
         // Clone shares the Arc — no second push_ok needed.
-        clone
-            .fill(TransactionRequest::default(), &provider)
-            .await
-            .unwrap();
+        clone.fill(TransactionRequest::default(), &provider).await.unwrap();
     }
 
     // ── FeeLimitFiller ───────────────────────────────────────────────────────
@@ -553,9 +519,7 @@ mod tests {
     #[tokio::test]
     async fn join_fill_runs_tapos_and_fee_limit() {
         let provider = mock_provider();
-        provider
-            .transport()
-            .push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
+        provider.transport().push_ok("get_now_block", block(0x0011_2233_4455_6677, 1_000_000));
 
         let limit = Trx::from_sun_unchecked(10_000_000);
         let join = JoinFill::new(TaposFiller::new(), FeeLimitFiller::new(limit));

--- a/crates/provider/src/lib.rs
+++ b/crates/provider/src/lib.rs
@@ -4,6 +4,9 @@
 #![cfg_attr(not(test), warn(unused_crate_dependencies))]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 
+#[macro_use]
+extern crate tracing;
+
 pub mod builders;
 pub mod ext;
 pub mod fillers;

--- a/crates/provider/src/provider/builder.rs
+++ b/crates/provider/src/provider/builder.rs
@@ -62,10 +62,7 @@ impl<F: TxFiller> ProviderBuilder<F> {
     /// use tronz_provider::{ProviderBuilder, transport::grpc::TRONGRID_MAINNET};
     /// # async fn run() -> tronz_provider::Result<()> {
     /// let api_key: Option<String> = std::env::var("TRON_API_KEY").ok();
-    /// let provider = ProviderBuilder::new()
-    ///     .maybe_api_key(api_key)
-    ///     .on_grpc(TRONGRID_MAINNET)
-    ///     .await?;
+    /// let provider = ProviderBuilder::new().maybe_api_key(api_key).on_grpc(TRONGRID_MAINNET).await?;
     /// # Ok(()) }
     /// ```
     pub fn maybe_api_key(mut self, key: Option<impl Into<String>>) -> Self {
@@ -108,22 +105,14 @@ impl<F: TxFiller> ProviderBuilder<F> {
     pub fn with_recommended_fillers(
         self,
     ) -> ProviderBuilder<JoinFill<JoinFill<F, TaposFiller>, FeeLimitFiller>> {
-        self.with_tapos()
-            .with_fee_limit(Trx::from_sun_unchecked(20_000_000))
+        self.with_tapos().with_fee_limit(Trx::from_sun_unchecked(20_000_000))
     }
 
     /// Add the TAPOS filler (required before broadcasting client-built txs).
     pub fn with_tapos(self) -> ProviderBuilder<JoinFill<F, TaposFiller>> {
         // Destructure so adding a transport-config field later is a compile
         // error here, not a silently dropped setting.
-        let Self {
-            filler,
-            api_key,
-            connect_timeout,
-            request_timeout,
-            retry,
-            endpoints,
-        } = self;
+        let Self { filler, api_key, connect_timeout, request_timeout, retry, endpoints } = self;
         ProviderBuilder {
             filler: JoinFill::new(filler, TaposFiller::new()),
             api_key,
@@ -136,14 +125,7 @@ impl<F: TxFiller> ProviderBuilder<F> {
 
     /// Add a default `fee_limit` for contract operations.
     pub fn with_fee_limit(self, limit: Trx) -> ProviderBuilder<JoinFill<F, FeeLimitFiller>> {
-        let Self {
-            filler,
-            api_key,
-            connect_timeout,
-            request_timeout,
-            retry,
-            endpoints,
-        } = self;
+        let Self { filler, api_key, connect_timeout, request_timeout, retry, endpoints } = self;
         ProviderBuilder {
             filler: JoinFill::new(filler, FeeLimitFiller::new(limit)),
             api_key,
@@ -159,14 +141,7 @@ impl<F: TxFiller> ProviderBuilder<F> {
         self,
         signer: S,
     ) -> ProviderBuilder<JoinFill<F, SignerFiller<S>>> {
-        let Self {
-            filler,
-            api_key,
-            connect_timeout,
-            request_timeout,
-            retry,
-            endpoints,
-        } = self;
+        let Self { filler, api_key, connect_timeout, request_timeout, retry, endpoints } = self;
         ProviderBuilder {
             filler: JoinFill::new(filler, SignerFiller::new(signer)),
             api_key,
@@ -198,13 +173,9 @@ impl<F: TxFiller> ProviderBuilder<F> {
         if let Some(r) = self.retry {
             cfg.retry = r;
         }
-        let transport = GrpcTransport::connect_with_config(uri, cfg)
-            .await
-            .map_err(Error::Transport)?;
-        Ok(FilledProvider::new(
-            RootProvider::new(transport),
-            self.filler,
-        ))
+        let transport =
+            GrpcTransport::connect_with_config(uri, cfg).await.map_err(Error::Transport)?;
+        Ok(FilledProvider::new(RootProvider::new(transport), self.filler))
     }
 
     /// Connect with an explicit TronGrid API key.
@@ -287,10 +258,7 @@ impl<T: TronTransport, F: TxFiller + HasSigner + 'static> TronProvider for Fille
             .map_err(Error::local_usage)?;
 
         let tx_id = raw.tx_id();
-        let signed = SignedTransaction {
-            raw,
-            signatures: vec![sig],
-        };
+        let signed = SignedTransaction { raw, signatures: vec![sig] };
         self.inner
             .transport()
             .broadcast_transaction(&signed)
@@ -321,10 +289,7 @@ impl<T: TronTransport, F: TxFiller + HasSigner + 'static> FilledProvider<T, F> {
         filler.fill_sync(&mut req); // second sync pass after async fill
 
         // ── 2. Route contract → transport build call ─────────────────────────
-        let contract = req
-            .contract
-            .take()
-            .ok_or(Error::missing_field("contract"))?;
+        let contract = req.contract.take().ok_or(Error::missing_field("contract"))?;
         let transport = self.inner.transport();
 
         let raw_result = match contract {

--- a/crates/provider/src/provider/mod.rs
+++ b/crates/provider/src/provider/mod.rs
@@ -61,31 +61,19 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     /// Fetch the latest block.
     fn get_now_block(&self) -> impl Future<Output = Result<BlockInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_now_block()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_now_block().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch a block by height.
     fn get_block_by_number(&self, num: i64) -> impl Future<Output = Result<BlockInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_block_by_number(num)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_block_by_number(num).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch on-chain account state.
     fn get_account(&self, address: Address) -> impl Future<Output = Result<AccountInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_account(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_account(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch account resource usage.
@@ -94,11 +82,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         address: Address,
     ) -> impl Future<Output = Result<AccountResource>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_account_resource(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_account_resource(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch a transaction by id.
@@ -107,11 +91,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         tx_id: TxId,
     ) -> impl Future<Output = Result<SignedTransaction>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_transaction_by_id(tx_id)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_transaction_by_id(tx_id).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch a transaction's receipt/info.
@@ -123,11 +103,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         tx_id: TxId,
     ) -> impl Future<Output = Result<Option<TransactionInfo>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_transaction_info(tx_id)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_transaction_info(tx_id).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Query delegations between two accounts (Stake 1.0, legacy).
@@ -138,9 +114,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     ) -> impl Future<Output = Result<Vec<DelegatedResource>>> + Send {
         let t = self.transport().clone();
         async move {
-            t.get_delegated_resource_v1(from, to)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_delegated_resource_v1(from, to).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
@@ -165,9 +139,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     ) -> impl Future<Output = Result<Vec<DelegatedResource>>> + Send {
         let t = self.transport().clone();
         async move {
-            t.get_delegated_resource(from, to)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_delegated_resource(from, to).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
@@ -178,9 +150,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     ) -> impl Future<Output = Result<DelegatedResourceIndex>> + Send {
         let t = self.transport().clone();
         async move {
-            t.get_delegated_resource_index(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_delegated_resource_index(address).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
@@ -201,21 +171,13 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     /// Query the pending (unclaimed) reward.
     fn get_reward(&self, address: Address) -> impl Future<Output = Result<Trx>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_reward(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_reward(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch chain parameters.
     fn chain_parameters(&self) -> impl Future<Output = Result<HashMap<String, i64>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_chain_parameters()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_chain_parameters().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch contract metadata including the deployed runtime bytecode.
@@ -224,21 +186,13 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         address: Address,
     ) -> impl Future<Output = Result<SmartContractInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_contract_info(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_contract_info(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// List all super representatives and candidates.
     fn list_witnesses(&self) -> impl Future<Output = Result<Vec<WitnessInfo>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.list_witnesses()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.list_witnesses().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     // ---------- New pure query methods ----------
@@ -246,101 +200,61 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     /// Fetch the bandwidth price schedule string.
     fn get_bandwidth_prices(&self) -> impl Future<Output = Result<String>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_bandwidth_prices()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_bandwidth_prices().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the energy price schedule string.
     fn get_energy_prices(&self) -> impl Future<Output = Result<String>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_energy_prices()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_energy_prices().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the memo fee schedule.
     fn get_memo_fee(&self) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_memo_fee()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_memo_fee().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the next maintenance time (unix ms).
     fn get_next_maintenance_time(&self) -> impl Future<Output = Result<i64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_next_maintenance_time()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_next_maintenance_time().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the total amount of TRX burned.
     fn get_burn_trx(&self) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_burn_trx()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_burn_trx().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the total number of transactions ever processed.
     fn get_total_transactions(&self) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_total_transactions()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_total_transactions().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch basic info about the connected node.
     fn get_node_info(&self) -> impl Future<Output = Result<NodeInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_node_info()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_node_info().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// List known gossip-network peer addresses.
     fn list_nodes(&self) -> impl Future<Output = Result<Vec<NodeAddress>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.list_nodes()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.list_nodes().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch dynamic chain properties.
     fn get_dynamic_properties(&self) -> impl Future<Output = Result<ChainProperties>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_dynamic_properties()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_dynamic_properties().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch a block by its hash.
     fn get_block_by_id(&self, block_id: B256) -> impl Future<Output = Result<BlockInfo>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_block_by_id(block_id)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_block_by_id(block_id).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the `count` most recent blocks.
@@ -349,11 +263,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         count: i64,
     ) -> impl Future<Output = Result<Vec<BlockInfo>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_blocks_by_latest_num(count)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_blocks_by_latest_num(count).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch blocks in the range `[start, end)`.
@@ -363,11 +273,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         end: i64,
     ) -> impl Future<Output = Result<Vec<BlockInfo>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_blocks_by_limit(start, end)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_blocks_by_limit(start, end).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Count transactions in a block by block number.
@@ -429,11 +335,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     /// Fetch the number of pending transactions.
     fn get_pending_size(&self) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_pending_size()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_pending_size().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch a single pending transaction by id.
@@ -443,20 +345,14 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     ) -> impl Future<Output = Result<RawTransaction>> + Send {
         let t = self.transport().clone();
         async move {
-            t.get_transaction_from_pending(tx_id)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_transaction_from_pending(tx_id).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
     /// Fetch all pending transactions.
     fn get_pending_transactions(&self) -> impl Future<Output = Result<Vec<RawTransaction>>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_pending_transactions()
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_pending_transactions().await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Query sign-weight for a transaction: how much signature weight has been
@@ -471,9 +367,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         let t = self.transport().clone();
         let tx = tx.clone();
         async move {
-            t.get_transaction_sign_weight(&tx)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_transaction_sign_weight(&tx).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
@@ -485,40 +379,26 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         let t = self.transport().clone();
         let tx = tx.clone();
         async move {
-            t.get_transaction_approved_list(&tx)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_transaction_approved_list(&tx).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
     /// Fetch bandwidth/energy net-usage for an account.
     fn get_account_net(&self, address: Address) -> impl Future<Output = Result<AccountNet>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_account_net(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_account_net(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the brokerage ratio for a super representative.
     fn get_brokerage(&self, address: Address) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_brokerage(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_brokerage(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     /// Fetch the unclaimed reward (raw sun) for an address.
     fn get_reward_info(&self, address: Address) -> impl Future<Output = Result<u64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.get_reward_info(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.get_reward_info(address).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     // ---------- Transaction builders (lazy — no I/O until `.send()`) ----------
@@ -639,9 +519,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
     ) -> impl Future<Output = Result<i64>> + Send {
         let t = self.transport().clone();
         async move {
-            t.get_available_unfreeze_count(address)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
+            t.get_available_unfreeze_count(address).await.map_err(|e| ProviderError::from(e.into()))
         }
     }
 
@@ -730,11 +608,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         params: TriggerSmartContract,
     ) -> impl Future<Output = Result<i64>> + Send {
         let t = self.transport().clone();
-        async move {
-            t.estimate_energy(params)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))
-        }
+        async move { t.estimate_energy(params).await.map_err(|e| ProviderError::from(e.into())) }
     }
 
     // ---------- Low-level ----------
@@ -773,9 +647,7 @@ pub trait TronProvider: Clone + Send + Sync + 'static + private::Sealed {
         let this = self.clone();
         async move {
             let tx_id = tx.raw.tx_id();
-            t.broadcast_transaction(&tx)
-                .await
-                .map_err(|e| ProviderError::from(e.into()))?;
+            t.broadcast_transaction(&tx).await.map_err(|e| ProviderError::from(e.into()))?;
             Ok(PendingTransaction::new(this, tx_id))
         }
     }

--- a/crates/provider/src/provider/root.rs
+++ b/crates/provider/src/provider/root.rs
@@ -21,21 +21,13 @@ struct RootProviderInner<T> {
 impl<T: TronTransport> RootProvider<T> {
     /// Create a read-only provider.
     pub fn new(transport: T) -> Self {
-        Self {
-            inner: Arc::new(RootProviderInner {
-                transport,
-                signer_address: None,
-            }),
-        }
+        Self { inner: Arc::new(RootProviderInner { transport, signer_address: None }) }
     }
 
     /// Create a provider that knows its signer's address.
     pub fn new_with_signer(transport: T, signer_address: Address) -> Self {
         Self {
-            inner: Arc::new(RootProviderInner {
-                transport,
-                signer_address: Some(signer_address),
-            }),
+            inner: Arc::new(RootProviderInner { transport, signer_address: Some(signer_address) }),
         }
     }
 

--- a/crates/provider/src/transport/grpc/codec.rs
+++ b/crates/provider/src/transport/grpc/codec.rs
@@ -46,15 +46,11 @@ fn addr(bytes: Vec<u8>) -> Result<Address, TransportErrorKind> {
 }
 
 fn opt_addr(bytes: Vec<u8>) -> Option<Address> {
-    if bytes.is_empty() {
-        None
-    } else {
-        Address::from_slice(&bytes).ok()
-    }
+    if bytes.is_empty() { None } else { Address::from_slice(&bytes).ok() }
 }
 
 /// Convert a byte vec to a B256. Returns `B256::ZERO` when the slice is not
-/// exactly 32 bytes, and emits a `tracing::warn!`.
+/// exactly 32 bytes, and emits a `warn!`.
 ///
 /// This is acceptable for log topics (a wrong-length topic simply won't match
 /// any filter) but **not** for block hashes — see [`block_from_extention`]
@@ -65,10 +61,7 @@ fn b256(bytes: Vec<u8>) -> B256 {
         arr.copy_from_slice(&bytes);
         B256::from(arr)
     } else {
-        tracing::warn!(
-            len = bytes.len(),
-            "unexpected b256 byte length from node, substituting B256::ZERO"
-        );
+        warn!(len = bytes.len(), "unexpected b256 byte length from node, substituting B256::ZERO");
         B256::ZERO
     }
 }
@@ -95,11 +88,7 @@ pub(super) fn block_from_extention(
         )));
     }
 
-    Ok(BlockInfo {
-        number: raw.number,
-        hash: b256(blockid),
-        timestamp: raw.timestamp,
-    })
+    Ok(BlockInfo { number: raw.number, hash: b256(blockid), timestamp: raw.timestamp })
 }
 
 // ── Account ───────────────────────────────────────────────────────────────────
@@ -114,20 +103,14 @@ pub(super) fn account_from_proto(
     queried: Address,
 ) -> Result<AccountInfo, TransportErrorKind> {
     let is_activated = !a.address.is_empty();
-    let address = if a.address.is_empty() {
-        queried
-    } else {
-        addr(a.address.clone())?
-    };
+    let address = if a.address.is_empty() { queried } else { addr(a.address.clone())? };
 
     let frozen_v2 = a
         .frozen_v2
         .into_iter()
         .filter_map(|f| {
-            tronz_primitives::ResourceCode::from_i32(f.r#type).map(|r| FreezeV2 {
-                resource: r,
-                amount: Trx::from_sun_unchecked(f.amount),
-            })
+            tronz_primitives::ResourceCode::from_i32(f.r#type)
+                .map(|r| FreezeV2 { resource: r, amount: Trx::from_sun_unchecked(f.amount) })
         })
         .collect();
 
@@ -148,24 +131,21 @@ pub(super) fn account_from_proto(
         .into_iter()
         .filter_map(|v| {
             addr(v.vote_address)
-                .inspect_err(|e| tracing::warn!("skipping vote entry with bad address: {e}"))
+                .inspect_err(|e| warn!("skipping vote entry with bad address: {e}"))
                 .ok()
-                .map(|va| Vote {
-                    vote_address: va,
-                    vote_count: v.vote_count,
-                })
+                .map(|va| Vote { vote_address: va, vote_count: v.vote_count })
         })
         .collect();
 
     let permissions = AccountPermissions {
         owner: a.owner_permission.and_then(|p| {
             permission_from_proto(p)
-                .inspect_err(|e| tracing::warn!("skipping malformed owner permission: {e}"))
+                .inspect_err(|e| warn!("skipping malformed owner permission: {e}"))
                 .ok()
         }),
         witness: a.witness_permission.and_then(|p| {
             permission_from_proto(p)
-                .inspect_err(|e| tracing::warn!("skipping malformed witness permission: {e}"))
+                .inspect_err(|e| warn!("skipping malformed witness permission: {e}"))
                 .ok()
         }),
         actives: a
@@ -173,7 +153,7 @@ pub(super) fn account_from_proto(
             .into_iter()
             .filter_map(|p| {
                 permission_from_proto(p)
-                    .inspect_err(|e| tracing::warn!("skipping malformed active permission: {e}"))
+                    .inspect_err(|e| warn!("skipping malformed active permission: {e}"))
                     .ok()
             })
             .collect(),
@@ -198,20 +178,12 @@ fn permission_from_proto(p: proto::Permission) -> Result<Permission, TransportEr
         .into_iter()
         .filter_map(|k| {
             addr(k.address)
-                .inspect_err(|e| tracing::warn!("skipping permission key with bad address: {e}"))
+                .inspect_err(|e| warn!("skipping permission key with bad address: {e}"))
                 .ok()
-                .map(|a| PermissionKey {
-                    address: a,
-                    weight: k.weight,
-                })
+                .map(|a| PermissionKey { address: a, weight: k.weight })
         })
         .collect();
-    Ok(Permission {
-        id: p.id,
-        permission_name: p.permission_name,
-        threshold: p.threshold,
-        keys,
-    })
+    Ok(Permission { id: p.id, permission_name: p.permission_name, threshold: p.threshold, keys })
 }
 
 pub(super) fn account_resource_from_proto(r: proto::AccountResourceMessage) -> AccountResource {
@@ -253,7 +225,7 @@ pub(super) fn signed_tx_from_proto(
         .iter()
         .filter_map(|s| {
             RecoverableSignature::from_bytes(s)
-                .inspect_err(|e| tracing::warn!("skipping malformed signature: {e}"))
+                .inspect_err(|e| warn!("skipping malformed signature: {e}"))
                 .ok()
         })
         .collect();
@@ -290,11 +262,7 @@ pub(super) fn transaction_info_from_proto(
         TxId::from(bytes)
     };
 
-    let status = if info.result == 0 {
-        TxStatus::Success
-    } else {
-        TxStatus::Failed
-    };
+    let status = if info.result == 0 { TxStatus::Success } else { TxStatus::Failed };
 
     let receipt = info.receipt.unwrap_or_default();
     let contract_result = match receipt.result {
@@ -373,11 +341,7 @@ pub(super) fn constant_result_from_extention(
         None
     };
 
-    Ok(ConstantCallResult {
-        output,
-        energy_used: ext.energy_used,
-        revert_reason,
-    })
+    Ok(ConstantCallResult { output, energy_used: ext.energy_used, revert_reason })
 }
 
 /// Convert a proto `SmartContract.ABI` to a JSON ABI byte array compatible
@@ -463,10 +427,7 @@ pub(super) fn smart_contract_from_proto(c: proto::SmartContract) -> SmartContrac
 pub(super) fn smart_contract_info_from_wrapper(
     w: proto::SmartContractDataWrapper,
 ) -> SmartContractInfo {
-    let mut info = w
-        .smart_contract
-        .map(smart_contract_from_proto)
-        .unwrap_or_default();
+    let mut info = w.smart_contract.map(smart_contract_from_proto).unwrap_or_default();
     if !w.runtimecode.is_empty() {
         info.runtime_bytecode = Some(Bytes::from(w.runtimecode));
     }
@@ -522,10 +483,7 @@ fn permission_to_proto(p: Permission) -> proto::Permission {
         keys: p
             .keys
             .into_iter()
-            .map(|k| proto::Key {
-                address: addr_bytes(k.address),
-                weight: k.weight,
-            })
+            .map(|k| proto::Key { address: addr_bytes(k.address), weight: k.weight })
             .collect(),
     }
 }
@@ -667,9 +625,7 @@ pub(super) fn participate_asset_issue_to_proto(
 }
 
 pub(super) fn unfreeze_asset_to_proto(p: UnfreezeAssetContract) -> proto::UnfreezeAssetContract {
-    proto::UnfreezeAssetContract {
-        owner_address: addr_bytes(p.owner_address),
-    }
+    proto::UnfreezeAssetContract { owner_address: addr_bytes(p.owner_address) }
 }
 
 pub(super) fn update_asset_to_proto(p: UpdateAssetContract) -> proto::UpdateAssetContract {
@@ -737,16 +693,8 @@ pub(super) fn delegated_resource_index_from_proto(
 ) -> Result<DelegatedResourceIndex, TransportErrorKind> {
     Ok(DelegatedResourceIndex {
         account: addr(idx.account)?,
-        from_accounts: idx
-            .from_accounts
-            .into_iter()
-            .filter_map(|b| addr(b).ok())
-            .collect(),
-        to_accounts: idx
-            .to_accounts
-            .into_iter()
-            .filter_map(|b| addr(b).ok())
-            .collect(),
+        from_accounts: idx.from_accounts.into_iter().filter_map(|b| addr(b).ok()).collect(),
+        to_accounts: idx.to_accounts.into_iter().filter_map(|b| addr(b).ok()).collect(),
     })
 }
 
@@ -782,11 +730,7 @@ pub(super) fn proposal_from_proto(p: proto::Proposal) -> ProposalInfo {
     } else {
         Address::from_slice(&p.proposer_address).ok()
     };
-    let approvals = p
-        .approvals
-        .into_iter()
-        .filter_map(|b| Address::from_slice(&b).ok())
-        .collect();
+    let approvals = p.approvals.into_iter().filter_map(|b| Address::from_slice(&b).ok()).collect();
     ProposalInfo {
         proposal_id: p.proposal_id,
         proposer_address,
@@ -878,11 +822,7 @@ pub(super) fn block_from_plain(block: proto::Block) -> Result<BlockInfo, Transpo
     let num_be = raw.number.to_be_bytes();
     block_id[0..8].copy_from_slice(&num_be);
 
-    Ok(BlockInfo {
-        number: raw.number,
-        hash: B256::from(block_id),
-        timestamp: raw.timestamp,
-    })
+    Ok(BlockInfo { number: raw.number, hash: B256::from(block_id), timestamp: raw.timestamp })
 }
 
 // ── Raw transaction from plain Transaction proto ───────────────────────────────
@@ -892,11 +832,8 @@ pub(super) fn raw_from_plain(tx: proto::Transaction) -> Result<RawTransaction, T
     use prost::Message as _;
     use sha2::{Digest, Sha256};
 
-    let (expiration, timestamp) = tx
-        .raw_data
-        .as_ref()
-        .map(|r| (r.expiration, r.timestamp))
-        .unwrap_or((0, 0));
+    let (expiration, timestamp) =
+        tx.raw_data.as_ref().map(|r| (r.expiration, r.timestamp)).unwrap_or((0, 0));
 
     let tx_id_bytes: [u8; 32] = if let Some(ref raw) = tx.raw_data {
         Sha256::digest(raw.encode_to_vec()).into()
@@ -1041,16 +978,7 @@ pub(super) fn sign_weight_from_proto(
 
     let required_weight = w.permission.as_ref().map(|p| p.threshold).unwrap_or(0);
 
-    let result = w
-        .result
-        .as_ref()
-        .map(|r| r.message.clone())
-        .unwrap_or_default();
+    let result = w.result.as_ref().map(|r| r.message.clone()).unwrap_or_default();
 
-    Ok(SignWeight {
-        approved_list,
-        current_weight: w.current_weight,
-        required_weight,
-        result,
-    })
+    Ok(SignWeight { approved_list, current_weight: w.current_weight, required_weight, result })
 }

--- a/crates/provider/src/transport/grpc/mod.rs
+++ b/crates/provider/src/transport/grpc/mod.rs
@@ -71,7 +71,7 @@ impl Interceptor for ApiKeyInterceptor {
                 Err(_) => {
                     // Invalid ASCII — log and continue rather than hard-failing
                     // a potentially valid RPC call.
-                    tracing::warn!(
+                    warn!(
                         "TronGrid API key contains non-ASCII characters; skipping header injection"
                     );
                 }
@@ -129,10 +129,7 @@ impl Default for RetryConfig {
 impl RetryConfig {
     /// A policy that never retries — equivalent to `max_attempts = 1`.
     pub fn disabled() -> Self {
-        Self {
-            max_attempts: 1,
-            ..Default::default()
-        }
+        Self { max_attempts: 1, ..Default::default() }
     }
 
     /// Set the maximum number of attempts (including the first).
@@ -312,11 +309,7 @@ impl GrpcTransport {
             Channel::balance_list(endpoints.into_iter())
         };
 
-        Ok(Self {
-            channel,
-            api_key: cfg.api_key,
-            retry: cfg.retry,
-        })
+        Ok(Self { channel, api_key: cfg.api_key, retry: cfg.retry })
     }
 
     /// Build a tonic [`Endpoint`] from a URI, applying the connection timeouts
@@ -373,16 +366,15 @@ impl GrpcTransport {
                     // Jitter the sleep value only; advance the base backoff
                     // separately so randomness never accumulates in the sequence.
                     let jittered = backoff.mul_f64(0.75 + fastrand::f64() * 0.5);
-                    tracing::debug!(
+                    debug!(
                         attempt,
                         backoff_ms = jittered.as_millis(),
                         error = %e,
                         "retrying gRPC call"
                     );
                     tokio::time::sleep(jittered).await;
-                    backoff = backoff
-                        .mul_f64(self.retry.backoff_multiplier)
-                        .min(self.retry.max_backoff);
+                    backoff =
+                        backoff.mul_f64(self.retry.backoff_multiplier).min(self.retry.max_backoff);
                 }
             }
         }
@@ -430,11 +422,8 @@ impl GrpcTransport {
             TransportErrorKind::Malformed("missing transaction in extention".into())
         })?;
 
-        let (expiration, timestamp) = tx
-            .raw_data
-            .as_ref()
-            .map(|r| (r.expiration, r.timestamp))
-            .unwrap_or((0, 0));
+        let (expiration, timestamp) =
+            tx.raw_data.as_ref().map(|r| (r.expiration, r.timestamp)).unwrap_or((0, 0));
 
         let raw_proto = tx.encode_to_vec();
         RawTransaction::from_proto_extention(ext.txid, raw_proto, expiration, timestamp)
@@ -522,19 +511,13 @@ impl TronTransport for GrpcTransport {
     // --- Account ---
 
     async fn get_account(&self, address: Address) -> Result<AccountInfo, Self::Error> {
-        let req = proto::Account {
-            address: address.as_bytes().to_vec(),
-            ..Default::default()
-        };
+        let req = proto::Account { address: address.as_bytes().to_vec(), ..Default::default() };
         let account = retry_unary!(self, wallet_client, get_account, req)?;
         codec::account_from_proto(account, address)
     }
 
     async fn get_account_resource(&self, address: Address) -> Result<AccountResource, Self::Error> {
-        let req = proto::Account {
-            address: address.as_bytes().to_vec(),
-            ..Default::default()
-        };
+        let req = proto::Account { address: address.as_bytes().to_vec(), ..Default::default() };
         let res = retry_unary!(self, wallet_client, get_account_resource, req)?;
         Ok(codec::account_resource_from_proto(res))
     }
@@ -544,18 +527,12 @@ impl TronTransport for GrpcTransport {
     async fn broadcast_transaction(&self, tx: &SignedTransaction) -> Result<(), Self::Error> {
         let proto_tx = signed_to_proto(tx)?;
 
-        let ret = self
-            .wallet_client()
-            .broadcast_transaction(proto_tx)
-            .await?
-            .into_inner();
+        let ret = self.wallet_client().broadcast_transaction(proto_tx).await?.into_inner();
         Self::check_return(Some(ret))
     }
 
     async fn get_transaction_by_id(&self, tx_id: TxId) -> Result<SignedTransaction, Self::Error> {
-        let req = proto::BytesMessage {
-            value: tx_id.as_slice().to_vec(),
-        };
+        let req = proto::BytesMessage { value: tx_id.as_slice().to_vec() };
         let tx = retry_unary!(self, wallet_client, get_transaction_by_id, req)?;
         codec::signed_tx_from_proto(tx)
     }
@@ -564,9 +541,7 @@ impl TronTransport for GrpcTransport {
         &self,
         tx_id: TxId,
     ) -> Result<Option<TransactionInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: tx_id.as_slice().to_vec(),
-        };
+        let req = proto::BytesMessage { value: tx_id.as_slice().to_vec() };
         let info = retry_unary!(self, wallet_client, get_transaction_info_by_id, req)?;
         codec::transaction_info_from_proto(info)
     }
@@ -761,25 +736,15 @@ impl TronTransport for GrpcTransport {
             to_address: to.as_bytes().to_vec(),
         };
         let list = retry_unary!(self, wallet_client, get_delegated_resource, req)?;
-        list.delegated_resource
-            .into_iter()
-            .map(codec::delegated_resource_from_proto)
-            .collect()
+        list.delegated_resource.into_iter().map(codec::delegated_resource_from_proto).collect()
     }
 
     async fn get_delegated_resource_index_v1(
         &self,
         address: Address,
     ) -> Result<DelegatedResourceIndex, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
-        let idx = retry_unary!(
-            self,
-            wallet_client,
-            get_delegated_resource_account_index,
-            req
-        )?;
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
+        let idx = retry_unary!(self, wallet_client, get_delegated_resource_account_index, req)?;
         codec::delegated_resource_index_from_proto(idx)
     }
 
@@ -793,25 +758,15 @@ impl TronTransport for GrpcTransport {
             to_address: to.as_bytes().to_vec(),
         };
         let list = retry_unary!(self, wallet_client, get_delegated_resource_v2, req)?;
-        list.delegated_resource
-            .into_iter()
-            .map(codec::delegated_resource_from_proto)
-            .collect()
+        list.delegated_resource.into_iter().map(codec::delegated_resource_from_proto).collect()
     }
 
     async fn get_delegated_resource_index(
         &self,
         address: Address,
     ) -> Result<DelegatedResourceIndex, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
-        let idx = retry_unary!(
-            self,
-            wallet_client,
-            get_delegated_resource_account_index_v2,
-            req
-        )?;
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
+        let idx = retry_unary!(self, wallet_client, get_delegated_resource_account_index_v2, req)?;
         codec::delegated_resource_index_from_proto(idx)
     }
 
@@ -829,9 +784,7 @@ impl TronTransport for GrpcTransport {
     }
 
     async fn get_reward(&self, address: Address) -> Result<Trx, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let res = retry_unary!(self, wallet_client, get_reward_info, req)?;
         Ok(Trx::from_sun_unchecked(res.num))
     }
@@ -841,25 +794,17 @@ impl TronTransport for GrpcTransport {
     async fn get_chain_parameters(&self) -> Result<HashMap<String, i64>, Self::Error> {
         let req = EmptyMessage::default();
         let params = retry_unary!(self, wallet_client, get_chain_parameters, req)?;
-        Ok(params
-            .chain_parameter
-            .into_iter()
-            .map(|p| (p.key, p.value))
-            .collect())
+        Ok(params.chain_parameter.into_iter().map(|p| (p.key, p.value)).collect())
     }
 
     async fn get_contract(&self, address: Address) -> Result<SmartContractInfo, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let contract = retry_unary!(self, wallet_client, get_contract, req)?;
         Ok(codec::smart_contract_from_proto(contract))
     }
 
     async fn get_contract_info(&self, address: Address) -> Result<SmartContractInfo, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let wrapper = retry_unary!(self, wallet_client, get_contract_info, req)?;
         Ok(codec::smart_contract_info_from_wrapper(wrapper))
     }
@@ -867,11 +812,7 @@ impl TronTransport for GrpcTransport {
     async fn list_witnesses(&self) -> Result<Vec<WitnessInfo>, Self::Error> {
         let req = proto::EmptyMessage::default();
         let list = retry_unary!(self, wallet_client, list_witnesses, req)?;
-        Ok(list
-            .witnesses
-            .into_iter()
-            .filter_map(codec::witness_from_proto)
-            .collect())
+        Ok(list.witnesses.into_iter().filter_map(codec::witness_from_proto).collect())
     }
 
     // --- Governance ---
@@ -906,11 +847,7 @@ impl TronTransport for GrpcTransport {
     async fn list_proposals(&self) -> Result<Vec<ProposalInfo>, Self::Error> {
         let req = proto::EmptyMessage::default();
         let list = retry_unary!(self, wallet_client, list_proposals, req)?;
-        Ok(list
-            .proposals
-            .into_iter()
-            .map(codec::proposal_from_proto)
-            .collect())
+        Ok(list.proposals.into_iter().map(codec::proposal_from_proto).collect())
     }
 
     async fn get_paginated_proposal_list(
@@ -920,17 +857,11 @@ impl TronTransport for GrpcTransport {
     ) -> Result<Vec<ProposalInfo>, Self::Error> {
         let req = proto::PaginatedMessage { offset, limit };
         let list = retry_unary!(self, wallet_client, get_paginated_proposal_list, req)?;
-        Ok(list
-            .proposals
-            .into_iter()
-            .map(codec::proposal_from_proto)
-            .collect())
+        Ok(list.proposals.into_iter().map(codec::proposal_from_proto).collect())
     }
 
     async fn get_proposal_by_id(&self, proposal_id: i64) -> Result<ProposalInfo, Self::Error> {
-        let req = proto::BytesMessage {
-            value: proposal_id.to_be_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: proposal_id.to_be_bytes().to_vec() };
         let proposal = retry_unary!(self, wallet_client, get_proposal_by_id, req)?;
         Ok(codec::proposal_from_proto(proposal))
     }
@@ -959,9 +890,7 @@ impl TronTransport for GrpcTransport {
         &self,
         token_id: &str,
     ) -> Result<Option<AssetInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: token_id.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: token_id.as_bytes().to_vec() };
         let asset = retry_unary!(self, wallet_client, get_asset_issue_by_id, req)?;
         codec::asset_info_from_proto(asset)
     }
@@ -970,10 +899,7 @@ impl TronTransport for GrpcTransport {
         &self,
         address: Address,
     ) -> Result<Vec<AssetInfo>, Self::Error> {
-        let req = proto::Account {
-            address: address.as_bytes().to_vec(),
-            ..Default::default()
-        };
+        let req = proto::Account { address: address.as_bytes().to_vec(), ..Default::default() };
         let list = retry_unary!(self, wallet_client, get_asset_issue_by_account, req)?;
         list.asset_issue
             .into_iter()
@@ -995,9 +921,7 @@ impl TronTransport for GrpcTransport {
     }
 
     async fn get_asset_issue_by_name(&self, name: &str) -> Result<Option<AssetInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: name.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: name.as_bytes().to_vec() };
         let asset = retry_unary!(self, wallet_client, get_asset_issue_by_name, req)?;
         codec::asset_info_from_proto(asset)
     }
@@ -1006,9 +930,7 @@ impl TronTransport for GrpcTransport {
         &self,
         name: &str,
     ) -> Result<Vec<AssetInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: name.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: name.as_bytes().to_vec() };
         let list = retry_unary!(self, wallet_client, get_asset_issue_list_by_name, req)?;
         list.asset_issue
             .into_iter()
@@ -1208,9 +1130,7 @@ impl TronTransport for GrpcTransport {
     // --- Block queries ---
 
     async fn get_block_by_id(&self, block_id: B256) -> Result<BlockInfo, Self::Error> {
-        let req = proto::BytesMessage {
-            value: block_id.as_slice().to_vec(),
-        };
+        let req = proto::BytesMessage { value: block_id.as_slice().to_vec() };
         let block = retry_unary!(self, wallet_client, get_block_by_id, req)?;
         codec::block_from_plain(block)
     }
@@ -1218,10 +1138,7 @@ impl TronTransport for GrpcTransport {
     async fn get_blocks_by_latest_num(&self, count: i64) -> Result<Vec<BlockInfo>, Self::Error> {
         let req = proto::NumberMessage { num: count };
         let list = retry_unary!(self, wallet_client, get_block_by_latest_num2, req)?;
-        list.block
-            .into_iter()
-            .map(codec::block_from_extention)
-            .collect()
+        list.block.into_iter().map(codec::block_from_extention).collect()
     }
 
     async fn get_blocks_by_limit(
@@ -1229,15 +1146,9 @@ impl TronTransport for GrpcTransport {
         start: i64,
         end: i64,
     ) -> Result<Vec<BlockInfo>, Self::Error> {
-        let req = proto::BlockLimit {
-            start_num: start,
-            end_num: end,
-        };
+        let req = proto::BlockLimit { start_num: start, end_num: end };
         let list = retry_unary!(self, wallet_client, get_block_by_limit_next2, req)?;
-        list.block
-            .into_iter()
-            .map(codec::block_from_extention)
-            .collect()
+        list.block.into_iter().map(codec::block_from_extention).collect()
     }
 
     async fn get_transaction_count_by_block_num(&self, block_num: i64) -> Result<u64, Self::Error> {
@@ -1262,16 +1173,8 @@ impl TronTransport for GrpcTransport {
             offset,
             limit,
         };
-        let list = retry_unary!(
-            self,
-            wallet_extension_client,
-            get_transactions_from_this2,
-            req
-        )?;
-        list.transaction
-            .into_iter()
-            .map(GrpcTransport::raw_from_extention)
-            .collect()
+        let list = retry_unary!(self, wallet_extension_client, get_transactions_from_this2, req)?;
+        list.transaction.into_iter().map(GrpcTransport::raw_from_extention).collect()
     }
 
     async fn get_transactions_to(
@@ -1288,16 +1191,8 @@ impl TronTransport for GrpcTransport {
             offset,
             limit,
         };
-        let list = retry_unary!(
-            self,
-            wallet_extension_client,
-            get_transactions_to_this2,
-            req
-        )?;
-        list.transaction
-            .into_iter()
-            .map(GrpcTransport::raw_from_extention)
-            .collect()
+        let list = retry_unary!(self, wallet_extension_client, get_transactions_to_this2, req)?;
+        list.transaction.into_iter().map(GrpcTransport::raw_from_extention).collect()
     }
 
     async fn get_transaction_info_by_block_num(
@@ -1324,9 +1219,7 @@ impl TronTransport for GrpcTransport {
         &self,
         tx_id: TxId,
     ) -> Result<RawTransaction, Self::Error> {
-        let req = proto::BytesMessage {
-            value: tx_id.as_slice().to_vec(),
-        };
+        let req = proto::BytesMessage { value: tx_id.as_slice().to_vec() };
         let tx = retry_unary!(self, wallet_client, get_transaction_from_pending, req)?;
         codec::raw_from_plain(tx)
     }
@@ -1381,10 +1274,7 @@ impl TronTransport for GrpcTransport {
     // --- Account net ---
 
     async fn get_account_net(&self, address: Address) -> Result<AccountNet, Self::Error> {
-        let req = proto::Account {
-            address: address.as_bytes().to_vec(),
-            ..Default::default()
-        };
+        let req = proto::Account { address: address.as_bytes().to_vec(), ..Default::default() };
         let msg = retry_unary!(self, wallet_client, get_account_net, req)?;
         Ok(AccountNet {
             free_net_used: msg.free_net_used,
@@ -1428,17 +1318,13 @@ impl TronTransport for GrpcTransport {
     }
 
     async fn get_brokerage(&self, address: Address) -> Result<u64, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let res = retry_unary!(self, wallet_client, get_brokerage_info, req)?;
         Ok(res.num as u64)
     }
 
     async fn get_reward_info(&self, address: Address) -> Result<u64, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let res = retry_unary!(self, wallet_client, get_reward_info, req)?;
         Ok(res.num as u64)
     }
@@ -1484,10 +1370,7 @@ impl TronTransport for GrpcTransport {
     async fn list_exchanges(&self) -> Result<Vec<ExchangeInfo>, Self::Error> {
         let req = EmptyMessage {};
         let list = retry_unary!(self, wallet_client, list_exchanges, req)?;
-        list.exchanges
-            .into_iter()
-            .map(codec::exchange_info_from_proto)
-            .collect()
+        list.exchanges.into_iter().map(codec::exchange_info_from_proto).collect()
     }
 
     async fn get_paginated_exchange_list(
@@ -1497,10 +1380,7 @@ impl TronTransport for GrpcTransport {
     ) -> Result<Vec<ExchangeInfo>, Self::Error> {
         let req = proto::PaginatedMessage { offset, limit };
         let list = retry_unary!(self, wallet_client, get_paginated_exchange_list, req)?;
-        list.exchanges
-            .into_iter()
-            .map(codec::exchange_info_from_proto)
-            .collect()
+        list.exchanges.into_iter().map(codec::exchange_info_from_proto).collect()
     }
 
     async fn get_exchange_by_id(
@@ -1509,9 +1389,7 @@ impl TronTransport for GrpcTransport {
     ) -> Result<Option<ExchangeInfo>, Self::Error> {
         let mut id_bytes = [0u8; 8];
         id_bytes.copy_from_slice(&exchange_id.to_be_bytes());
-        let req = proto::BytesMessage {
-            value: id_bytes.to_vec(),
-        };
+        let req = proto::BytesMessage { value: id_bytes.to_vec() };
         let exchange = retry_unary!(self, wallet_client, get_exchange_by_id, req)?;
         if exchange.exchange_id == 0 && exchange.creator_address.is_empty() {
             return Ok(None);
@@ -1543,9 +1421,7 @@ impl TronTransport for GrpcTransport {
         &self,
         order_id: &[u8],
     ) -> Result<Option<MarketOrderInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: order_id.to_vec(),
-        };
+        let req = proto::BytesMessage { value: order_id.to_vec() };
         let order = retry_unary!(self, wallet_client, get_market_order_by_id, req)?;
         if order.order_id.is_empty() {
             return Ok(None);
@@ -1557,14 +1433,9 @@ impl TronTransport for GrpcTransport {
         &self,
         address: Address,
     ) -> Result<Vec<MarketOrderInfo>, Self::Error> {
-        let req = proto::BytesMessage {
-            value: address.as_bytes().to_vec(),
-        };
+        let req = proto::BytesMessage { value: address.as_bytes().to_vec() };
         let list = retry_unary!(self, wallet_client, get_market_order_by_account, req)?;
-        list.orders
-            .into_iter()
-            .map(codec::market_order_from_proto)
-            .collect()
+        list.orders.into_iter().map(codec::market_order_from_proto).collect()
     }
 
     async fn get_market_price_by_pair(
@@ -1577,11 +1448,7 @@ impl TronTransport for GrpcTransport {
             buy_token_id: buy_token_id.as_bytes().to_vec(),
         };
         let list = retry_unary!(self, wallet_client, get_market_price_by_pair, req)?;
-        Ok(list
-            .prices
-            .into_iter()
-            .map(codec::market_price_from_proto)
-            .collect())
+        Ok(list.prices.into_iter().map(codec::market_price_from_proto).collect())
     }
 
     async fn get_market_order_list_by_pair(
@@ -1594,19 +1461,12 @@ impl TronTransport for GrpcTransport {
             buy_token_id: buy_token_id.as_bytes().to_vec(),
         };
         let list = retry_unary!(self, wallet_client, get_market_order_list_by_pair, req)?;
-        list.orders
-            .into_iter()
-            .map(codec::market_order_from_proto)
-            .collect()
+        list.orders.into_iter().map(codec::market_order_from_proto).collect()
     }
 
     async fn get_market_pair_list(&self) -> Result<Vec<MarketOrderPair>, Self::Error> {
         let req = EmptyMessage {};
         let list = retry_unary!(self, wallet_client, get_market_pair_list, req)?;
-        Ok(list
-            .order_pair
-            .into_iter()
-            .map(codec::market_order_pair_from_proto)
-            .collect())
+        Ok(list.order_pair.into_iter().map(codec::market_order_pair_from_proto).collect())
     }
 }

--- a/crates/provider/src/transport/mock.rs
+++ b/crates/provider/src/transport/mock.rs
@@ -260,8 +260,7 @@ mod tests {
     #[tokio::test]
     async fn returns_queued_ok_responses_in_fifo_order() {
         let mock = MockTransport::new();
-        mock.push_ok::<u64>("get_memo_fee", 1)
-            .push_ok::<u64>("get_memo_fee", 2);
+        mock.push_ok::<u64>("get_memo_fee", 1).push_ok::<u64>("get_memo_fee", 2);
 
         assert_eq!(mock.get_memo_fee().await.unwrap(), 1);
         assert_eq!(mock.get_memo_fee().await.unwrap(), 2);
@@ -270,10 +269,7 @@ mod tests {
     #[tokio::test]
     async fn returns_queued_err_responses() {
         let mock = MockTransport::new();
-        mock.push_err::<u64>(
-            "get_burn_trx",
-            TransportErrorKind::Malformed("boom".to_owned()),
-        );
+        mock.push_err::<u64>("get_burn_trx", TransportErrorKind::Malformed("boom".to_owned()));
 
         let err = mock.get_burn_trx().await.unwrap_err();
         assert!(matches!(err, TransportErrorKind::Malformed(_)));
@@ -286,10 +282,7 @@ mod tests {
 
         // Exercises the real provider -> transport delegation path.
         let provider = RootProvider::new(mock);
-        assert_eq!(
-            provider.transport().get_total_transactions().await.unwrap(),
-            42
-        );
+        assert_eq!(provider.transport().get_total_transactions().await.unwrap(), 42);
     }
 
     #[tokio::test]

--- a/crates/provider/src/types/contract.rs
+++ b/crates/provider/src/types/contract.rs
@@ -95,10 +95,7 @@ impl ContractType {
     /// Whether this contract type requires a `fee_limit` to be set
     /// (smart-contract operations) versus native contracts that ignore it.
     pub fn needs_fee_limit(&self) -> bool {
-        matches!(
-            self,
-            ContractType::TriggerSmartContract(_) | ContractType::CreateSmartContract(_)
-        )
+        matches!(self, ContractType::TriggerSmartContract(_) | ContractType::CreateSmartContract(_))
     }
 
     /// The owner (sender) address of this contract operation.

--- a/crates/provider/src/types/receipt.rs
+++ b/crates/provider/src/types/receipt.rs
@@ -83,11 +83,7 @@ pub struct Log {
 impl Log {
     /// Construct a log from its three fields.
     pub fn new(address: Address, topics: Vec<B256>, data: impl Into<Bytes>) -> Self {
-        Self {
-            address,
-            topics,
-            data: data.into(),
-        }
+        Self { address, topics, data: data.into() }
     }
 }
 

--- a/crates/provider/src/types/transaction.rs
+++ b/crates/provider/src/types/transaction.rs
@@ -111,12 +111,7 @@ impl RawTransaction {
             .try_into()
             .map_err(|_| TransportErrorKind::Malformed("txid must be 32 bytes".into()))?;
 
-        Ok(Self {
-            expiration,
-            timestamp,
-            tx_id: TxId::from(tx_id_bytes),
-            raw_proto,
-        })
+        Ok(Self { expiration, timestamp, tx_id: TxId::from(tx_id_bytes), raw_proto })
     }
 
     /// The transaction id — `sha256` of the encoded `Transaction.raw`.

--- a/crates/provider/tests/integration.rs
+++ b/crates/provider/tests/integration.rs
@@ -52,10 +52,7 @@ const NILE_BOGUS_TOKEN_ID: &str = "9999999999";
 
 /// Build a plain read-only provider connected to Nile.
 async fn read_provider() -> impl TronProvider {
-    ProviderBuilder::new()
-        .on_grpc(TRONGRID_NILE)
-        .await
-        .expect("failed to connect to Nile testnet")
+    ProviderBuilder::new().on_grpc(TRONGRID_NILE).await.expect("failed to connect to Nile testnet")
 }
 
 /// Read `TRON_TEST_KEY` from the environment.
@@ -75,10 +72,8 @@ fn random_key_bytes() -> [u8; 32] {
     use std::hash::{BuildHasher, Hasher};
 
     let mut out = [0u8; 32];
-    let nanos = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap()
-        .as_nanos();
+    let nanos =
+        std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos();
     for (i, chunk) in out.chunks_mut(8).enumerate() {
         let mut hasher = std::collections::hash_map::RandomState::new().build_hasher();
         hasher.write_usize(i);
@@ -95,27 +90,13 @@ fn random_key_bytes() -> [u8; 32] {
 #[ignore = "requires network"]
 async fn test_get_now_block() {
     let provider = read_provider().await;
-    let block = provider
-        .get_now_block()
-        .await
-        .expect("get_now_block failed");
+    let block = provider.get_now_block().await.expect("get_now_block failed");
 
-    assert!(
-        block.number > 0,
-        "block number should be positive, got {}",
-        block.number
-    );
-    assert_ne!(
-        block.hash,
-        tronz_primitives::B256::ZERO,
-        "block hash should be non-zero"
-    );
+    assert!(block.number > 0, "block number should be positive, got {}", block.number);
+    assert_ne!(block.hash, tronz_primitives::B256::ZERO, "block hash should be non-zero");
     assert!(block.timestamp > 0, "block timestamp should be positive");
 
-    eprintln!(
-        "Nile head: block #{} (ts={})",
-        block.number, block.timestamp
-    );
+    eprintln!("Nile head: block #{} (ts={})", block.number, block.timestamp);
 }
 
 // ── Account ───────────────────────────────────────────────────────────────────
@@ -143,14 +124,8 @@ async fn test_get_account_never_activated_is_not_an_error() {
         .await
         .expect("get_account should succeed even for a never-activated address");
 
-    assert_eq!(
-        account.address, fresh_addr,
-        "returned address should match the queried address"
-    );
-    assert!(
-        !account.is_activated,
-        "fresh address must not be marked as activated"
-    );
+    assert_eq!(account.address, fresh_addr, "returned address should match the queried address");
+    assert!(!account.is_activated, "fresh address must not be marked as activated");
     assert_eq!(
         account.balance,
         tronz_primitives::Trx::ZERO,
@@ -162,25 +137,13 @@ async fn test_get_account_never_activated_is_not_an_error() {
 #[ignore = "requires network"]
 async fn test_get_account_activated() {
     let provider = read_provider().await;
-    let addr = NILE_ACTIVE_ADDR
-        .parse::<Address>()
-        .expect("invalid NILE_ACTIVE_ADDR constant");
+    let addr = NILE_ACTIVE_ADDR.parse::<Address>().expect("invalid NILE_ACTIVE_ADDR constant");
 
-    let account = provider
-        .get_account(addr)
-        .await
-        .expect("get_account failed");
+    let account = provider.get_account(addr).await.expect("get_account failed");
     assert_eq!(account.address, addr);
-    assert!(
-        account.is_activated,
-        "known active account should be activated"
-    );
+    assert!(account.is_activated, "known active account should be activated");
 
-    eprintln!(
-        "Account {} balance: {} TRX",
-        addr,
-        account.balance.as_sun() as f64 / 1_000_000.0
-    );
+    eprintln!("Account {} balance: {} TRX", addr, account.balance.as_sun() as f64 / 1_000_000.0);
 }
 
 // ── Transaction not found ─────────────────────────────────────────────────────
@@ -224,10 +187,7 @@ async fn test_get_asset_info_existing_token() {
         .expect("get_asset_info failed for a known token")
         .expect("known token should be found");
 
-    assert_eq!(
-        info.id, NILE_TRC10_TOKEN_ID,
-        "returned token id should match query"
-    );
+    assert_eq!(info.id, NILE_TRC10_TOKEN_ID, "returned token id should match query");
     assert!(!info.name.is_empty(), "token name should not be empty");
 
     eprintln!(
@@ -247,10 +207,7 @@ async fn test_get_asset_info_nonexistent_token_returns_not_found() {
         .await
         .expect("transport should not error for bogus token");
 
-    assert!(
-        result.is_none(),
-        "expected None for bogus token, got: {result:?}"
-    );
+    assert!(result.is_none(), "expected None for bogus token, got: {result:?}");
 }
 
 /// `trc10_balance` for an account that holds none of the token must return `0`,
@@ -314,10 +271,7 @@ async fn test_trx_transfer_and_receipt() {
     eprintln!("Broadcast tx: {}", pending.tx_id());
 
     let info = pending.get_receipt().await.expect("get_receipt failed");
-    eprintln!(
-        "Confirmed: block #{}, energy_used={}",
-        info.block_number, info.energy_usage
-    );
+    eprintln!("Confirmed: block #{}, energy_used={}", info.block_number, info.energy_usage);
 
     assert_eq!(
         info.status,
@@ -337,14 +291,10 @@ async fn test_usdt_balance_of_constant_call() {
 
     let provider = read_provider().await;
 
-    let contract = NILE_USDT_CONTRACT
-        .parse::<Address>()
-        .expect("bad USDT address");
+    let contract = NILE_USDT_CONTRACT.parse::<Address>().expect("bad USDT address");
 
     // `balanceOf(address)` selector = 0x70a08231; arg = NILE_ACTIVE_ADDR (padded to 32 bytes).
-    let owner = NILE_ACTIVE_ADDR
-        .parse::<Address>()
-        .expect("bad active addr");
+    let owner = NILE_ACTIVE_ADDR.parse::<Address>().expect("bad active addr");
     let mut data = vec![0x70u8, 0xa0, 0x82, 0x31];
     // ABI-encode the address: 12 zero bytes + 20 address bytes.
     data.extend_from_slice(&[0u8; 12]);
@@ -366,11 +316,7 @@ async fn test_usdt_balance_of_constant_call() {
         .expect("trigger_constant_contract failed");
 
     // We just check that the output is 32 bytes (a uint256) — not the actual value.
-    assert_eq!(
-        result.output.len(),
-        32,
-        "balanceOf should return a 32-byte uint256"
-    );
+    assert_eq!(result.output.len(), 32, "balanceOf should return a 32-byte uint256");
 
     let balance_u256 = tronz_primitives::U256::from_be_slice(&result.output);
     eprintln!("USDT balanceOf({owner}): {balance_u256} (6 decimals)");
@@ -387,12 +333,8 @@ async fn test_estimate_energy_usdt_transfer() {
 
     let provider = read_provider().await;
 
-    let contract = NILE_USDT_CONTRACT
-        .parse::<Address>()
-        .expect("bad USDT address");
-    let caller = NILE_ACTIVE_ADDR
-        .parse::<Address>()
-        .expect("bad active addr");
+    let contract = NILE_USDT_CONTRACT.parse::<Address>().expect("bad USDT address");
+    let caller = NILE_ACTIVE_ADDR.parse::<Address>().expect("bad active addr");
 
     // `transfer(address,uint256)` selector = 0xa9059cbb
     // recipient = NILE_ACTIVE_ADDR, amount = 1
@@ -411,14 +353,8 @@ async fn test_estimate_energy_usdt_transfer() {
         token_id: 0,
     };
 
-    let energy = provider
-        .estimate_energy(params)
-        .await
-        .expect("estimate_energy failed");
+    let energy = provider.estimate_energy(params).await.expect("estimate_energy failed");
 
-    assert!(
-        energy > 0,
-        "energy estimate should be positive, got {energy}"
-    );
+    assert!(energy > 0, "energy estimate should be positive, got {energy}");
     eprintln!("Estimated energy for USDT transfer: {energy}");
 }

--- a/crates/signer-aws/src/signer.rs
+++ b/crates/signer-aws/src/signer.rs
@@ -83,12 +83,7 @@ impl AwsSigner {
         let pubkey = decode_pubkey(resp)?;
         let address = Address::from_public_key(&pubkey);
         debug!(%address, "AWS KMS signer ready");
-        Ok(Self {
-            kms,
-            key_id,
-            pubkey,
-            address,
-        })
+        Ok(Self { kms, key_id, pubkey, address })
     }
 
     /// The KMS key ID used by this signer.
@@ -103,9 +98,7 @@ impl AwsSigner {
 
     /// Fetch the public key for a given key ID from KMS.
     pub async fn get_pubkey_for_key(&self, key_id: String) -> Result<VerifyingKey, AwsSignerError> {
-        request_get_pubkey(&self.kms, key_id)
-            .await
-            .and_then(decode_pubkey)
+        request_get_pubkey(&self.kms, key_id).await.and_then(decode_pubkey)
     }
 
     /// Fetch the public key for this signer's key ID from KMS.
@@ -141,11 +134,7 @@ async fn request_get_pubkey(
     kms: &Client,
     key_id: String,
 ) -> Result<GetPublicKeyOutput, AwsSignerError> {
-    kms.get_public_key()
-        .key_id(key_id)
-        .send()
-        .await
-        .map_err(Into::into)
+    kms.get_public_key().key_id(key_id).send().await.map_err(Into::into)
 }
 
 #[instrument(skip(kms, digest), fields(digest = %digest), err)]
@@ -166,22 +155,14 @@ async fn request_sign_digest(
 
 /// Decode a KMS `GetPublicKey` response (DER SubjectPublicKeyInfo) into a [`VerifyingKey`].
 fn decode_pubkey(resp: GetPublicKeyOutput) -> Result<VerifyingKey, AwsSignerError> {
-    let raw = resp
-        .public_key
-        .as_ref()
-        .ok_or(AwsSignerError::PublicKeyNotFound)?;
+    let raw = resp.public_key.as_ref().ok_or(AwsSignerError::PublicKeyNotFound)?;
     let spki = spki::SubjectPublicKeyInfoRef::try_from(raw.as_ref())?;
-    Ok(VerifyingKey::from_sec1_bytes(
-        spki.subject_public_key.raw_bytes(),
-    )?)
+    Ok(VerifyingKey::from_sec1_bytes(spki.subject_public_key.raw_bytes())?)
 }
 
 /// Decode a KMS `Sign` response and normalize `s` to low-S (required by TRON, as in EIP-2).
 fn decode_signature(resp: SignOutput) -> Result<ecdsa::Signature, AwsSignerError> {
-    let raw = resp
-        .signature
-        .as_ref()
-        .ok_or(AwsSignerError::SignatureNotFound)?;
+    let raw = resp.signature.as_ref().ok_or(AwsSignerError::SignatureNotFound)?;
     let sig = ecdsa::Signature::from_der(raw.as_ref())?;
     Ok(sig.normalize_s().unwrap_or(sig))
 }

--- a/crates/signer/src/keystore.rs
+++ b/crates/signer/src/keystore.rs
@@ -188,9 +188,8 @@ pub fn decrypt(ks: &KeystoreFile, password: &str) -> Result<[u8; 32], SignerErro
     // ── Parse hex fields ──────────────────────────────────────────────────────
     let salt = hex::decode(&kp.salt)?;
     let iv_bytes = hex::decode(&ks.crypto.cipherparams.iv)?;
-    let iv: [u8; 16] = iv_bytes
-        .try_into()
-        .map_err(|_| KeystoreError::InvalidField("iv must be 16 bytes"))?;
+    let iv: [u8; 16] =
+        iv_bytes.try_into().map_err(|_| KeystoreError::InvalidField("iv must be 16 bytes"))?;
     let mut ciphertext = hex::decode(&ks.crypto.ciphertext)?;
     let stored_mac = hex::decode(&ks.crypto.mac)?;
 
@@ -256,19 +255,14 @@ fn encrypt_inner(
     cipher.apply_keystream(&mut ciphertext);
 
     // ── MAC: keccak256(derivedKey[16..32] || ciphertext) ─────────────────────
-    let mac = Keccak256::new()
-        .chain_update(&derived_key[16..])
-        .chain_update(ciphertext)
-        .finalize();
+    let mac = Keccak256::new().chain_update(&derived_key[16..]).chain_update(ciphertext).finalize();
 
     Ok(KeystoreFile {
         address: address.to_string(),
         crypto: CryptoJson {
             cipher: "aes-128-ctr".into(),
             ciphertext: hex::encode(ciphertext),
-            cipherparams: CipherparamsJson {
-                iv: hex::encode(iv),
-            },
+            cipherparams: CipherparamsJson { iv: hex::encode(iv) },
             kdf: "scrypt".into(),
             kdfparams: KdfparamsJson {
                 n: 1u64 << log_n,
@@ -305,16 +299,7 @@ mod tests {
     }
 
     fn encrypt_light(key: &[u8; 32], addr: &str, password: &str) -> KeystoreFile {
-        encrypt_inner(
-            key,
-            addr,
-            password,
-            &mut rand::rng(),
-            TEST_LOG_N,
-            TEST_R,
-            TEST_P,
-        )
-        .unwrap()
+        encrypt_inner(key, addr, password, &mut rand::rng(), TEST_LOG_N, TEST_R, TEST_P).unwrap()
     }
 
     // ── Round-trip ─────────────────────────────────────────────────────────────
@@ -340,10 +325,7 @@ mod tests {
         let key = test_key();
         let ks = encrypt_light(&key, ADDR, "pw");
         assert_eq!(ks.address, ADDR);
-        assert!(
-            ks.address.starts_with('T'),
-            "TRON address must start with T"
-        );
+        assert!(ks.address.starts_with('T'), "TRON address must start with T");
     }
 
     #[test]

--- a/crates/signer/src/local.rs
+++ b/crates/signer/src/local.rs
@@ -80,9 +80,7 @@ impl LocalSigner {
 impl core::fmt::Debug for LocalSigner {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         // Never print the private key.
-        f.debug_struct("LocalSigner")
-            .field("address", &self.address)
-            .finish_non_exhaustive()
+        f.debug_struct("LocalSigner").field("address", &self.address).finish_non_exhaustive()
     }
 }
 

--- a/crates/signer/src/mnemonic.rs
+++ b/crates/signer/src/mnemonic.rs
@@ -155,10 +155,7 @@ impl<W: Wordlist> MnemonicBuilder<W> {
     ///
     /// Returns an error if no phrase has been set.
     pub fn build(&self) -> Result<LocalSigner, SignerError> {
-        let phrase = self
-            .phrase
-            .as_deref()
-            .ok_or(MnemonicBuilderError::MissingPhrase)?;
+        let phrase = self.phrase.as_deref().ok_or(MnemonicBuilderError::MissingPhrase)?;
         let mnemonic = Mnemonic::<W>::new_from_phrase(phrase)?;
         xpriv_to_local_signer(
             &mnemonic.derive_key(&self.derivation_path, self.password.as_deref())?,
@@ -201,10 +198,7 @@ impl<W: Wordlist> MnemonicBuilder<W> {
     /// Useful for deriving many sequential accounts without re-processing the
     /// whole BIP-39 derivation each time.
     pub fn build_parent_key(&self) -> Result<MnemonicKey, SignerError> {
-        let phrase = self
-            .phrase
-            .as_deref()
-            .ok_or(MnemonicBuilderError::MissingPhrase)?;
+        let phrase = self.phrase.as_deref().ok_or(MnemonicBuilderError::MissingPhrase)?;
         let mnemonic = Mnemonic::<W>::new_from_phrase(phrase)?;
         let mut key = mnemonic.master_key(self.password.as_deref())?;
         // Traverse all but the last path component.
@@ -256,9 +250,7 @@ pub struct MnemonicKey {
 impl MnemonicKey {
     /// Derive a child key at `index` (unhardened).
     pub fn child(&self, index: u32) -> Result<Self, SignerError> {
-        Ok(Self {
-            key: self.key.derive_child(index)?,
-        })
+        Ok(Self { key: self.key.derive_child(index)? })
     }
 
     /// Extract a [`LocalSigner`] from this key.
@@ -273,12 +265,7 @@ impl MnemonicKey {
 
     /// Iterator over sequential child signers starting at `start`.
     pub fn children_from(&self, start: u32) -> MnemonicSignerIter {
-        MnemonicSignerIter {
-            state: IterState::Active {
-                key: self.clone(),
-                next: start,
-            },
-        }
+        MnemonicSignerIter { state: IterState::Active { key: self.clone(), next: start } }
     }
 }
 
@@ -313,17 +300,11 @@ enum IterState {
 
 impl MnemonicSignerIter {
     fn missing_phrase() -> Self {
-        Self {
-            state: IterState::Error {
-                error: Some(MnemonicBuilderError::MissingPhrase.into()),
-            },
-        }
+        Self { state: IterState::Error { error: Some(MnemonicBuilderError::MissingPhrase.into()) } }
     }
 
     fn error(e: SignerError) -> Self {
-        Self {
-            state: IterState::Error { error: Some(e) },
-        }
+        Self { state: IterState::Error { error: Some(e) } }
     }
 }
 
@@ -446,10 +427,8 @@ mod tests {
 
     #[test]
     fn build_random_returns_valid_signer() {
-        let (signer, phrase) = MnemonicBuilder::<English>::default()
-            .word_count(12)
-            .build_random()
-            .unwrap();
+        let (signer, phrase) =
+            MnemonicBuilder::<English>::default().word_count(12).build_random().unwrap();
         // Phrase must be 12 words.
         assert_eq!(phrase.split_whitespace().count(), 12);
         // Address must start with 'T' (base58check, TRON prefix byte 0x41).
@@ -458,18 +437,10 @@ mod tests {
 
     #[test]
     fn random_and_phrase_are_consistent() {
-        let (_, phrase) = MnemonicBuilder::<English>::default()
-            .word_count(12)
-            .build_random()
-            .unwrap();
-        let s1 = MnemonicBuilder::<English>::default()
-            .phrase(&phrase)
-            .build()
-            .unwrap();
-        let s2 = MnemonicBuilder::<English>::default()
-            .phrase(&phrase)
-            .build()
-            .unwrap();
+        let (_, phrase) =
+            MnemonicBuilder::<English>::default().word_count(12).build_random().unwrap();
+        let s1 = MnemonicBuilder::<English>::default().phrase(&phrase).build().unwrap();
+        let s2 = MnemonicBuilder::<English>::default().phrase(&phrase).build().unwrap();
         assert_eq!(s1.address(), s2.address());
     }
 
@@ -517,19 +488,13 @@ mod tests {
     #[test]
     fn missing_phrase_returns_error() {
         assert!(MnemonicBuilder::<English>::default().build().is_err());
-        let err = MnemonicBuilder::<English>::default()
-            .into_iter()
-            .next()
-            .unwrap()
-            .unwrap_err();
+        let err = MnemonicBuilder::<English>::default().into_iter().next().unwrap().unwrap_err();
         assert!(err.to_string().contains("phrase"));
     }
 
     #[test]
     fn phrase_set_random_returns_error() {
-        let result = MnemonicBuilder::<English>::default()
-            .phrase(ABANDON_PHRASE)
-            .build_random();
+        let result = MnemonicBuilder::<English>::default().phrase(ABANDON_PHRASE).build_random();
         assert!(result.is_err());
     }
 

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -612,11 +612,7 @@ fn rewrite_attr(inner: TokenStream2) -> Option<TokenStream2> {
                     }
                     let mut grp = Group::new(Delimiter::Parenthesis, kept);
                     grp.set_span(g.span());
-                    return Some(
-                        [toks[0].clone(), TokenTree::Group(grp)]
-                            .into_iter()
-                            .collect(),
-                    );
+                    return Some([toks[0].clone(), TokenTree::Group(grp)].into_iter().collect());
                 }
             }
             Some(inner)
@@ -781,11 +777,8 @@ fn rust_ty(ty: &SolType, alloy: &TokenStream2, aprim: &TokenStream2) -> Result<T
             }
         }
         SolType::Tuple(tuple) => {
-            let inners = tuple
-                .types
-                .iter()
-                .map(|t| rust_ty(t, alloy, aprim))
-                .collect::<Result<Vec<_>>>()?;
+            let inners =
+                tuple.types.iter().map(|t| rust_ty(t, alloy, aprim)).collect::<Result<Vec<_>>>()?;
             quote!((#(#inners,)*))
         }
         SolType::Custom(path) => {
@@ -822,10 +815,7 @@ fn int_ty(bits: u16, signed: bool, aprim: &TokenStream2) -> TokenStream2 {
 fn parse_hex(lit: &LitStr) -> Result<Vec<u8>> {
     let span = lit.span();
     let s = lit.value();
-    let s = s
-        .strip_prefix("0x")
-        .or_else(|| s.strip_prefix("0X"))
-        .unwrap_or(&s);
+    let s = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(&s);
     if s.len() % 2 != 0 {
         return Err(syn::Error::new(span, "bytecode hex string has odd length"));
     }
@@ -844,9 +834,6 @@ fn hex_nibble(b: u8, span: Span) -> Result<u8> {
         b'0'..=b'9' => Ok(b - b'0'),
         b'a'..=b'f' => Ok(b - b'a' + 10),
         b'A'..=b'F' => Ok(b - b'A' + 10),
-        _ => Err(syn::Error::new(
-            span,
-            format!("invalid hex byte '{}'", b as char),
-        )),
+        _ => Err(syn::Error::new(span, format!("invalid hex byte '{}'", b as char))),
     }
 }

--- a/crates/tronz/tests/tron_sol.rs
+++ b/crates/tronz/tests/tron_sol.rs
@@ -19,9 +19,7 @@ tron_sol! {
 #[test]
 fn default_path_encodes() {
     let owner: Address = "TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t".parse().unwrap();
-    let call = IERC20::balanceOfCall {
-        owner: owner.into(),
-    };
+    let call = IERC20::balanceOfCall { owner: owner.into() };
     // 4-byte selector + 32-byte address argument
     assert_eq!(call.abi_encode().len(), 36);
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -4,13 +4,20 @@ unstable_features  = true
 # Imports
 imports_granularity = "Crate"
 group_imports       = "StdExternalCrate"
+reorder_imports     = true
 
 # Width
-max_width    = 100
-comment_width = 100
-wrap_comments = true
+max_width             = 100
+comment_width         = 100
+wrap_comments         = true
+use_small_heuristics  = "Max"
+
+# Docs
+format_code_in_doc_comments  = true
+doc_comment_code_block_width = 100
 
 # Misc
-format_strings         = false
+format_strings           = false
+format_macro_matchers    = true
 use_field_init_shorthand = true
 use_try_shorthand        = true


### PR DESCRIPTION
## Description:
- Add missing rustfmt options to match alloy: `use_small_heuristics = "Max"`, `reorder_imports`, `format_code_in_doc_comments`, `format_macro_matchers`
- Re-format entire workspace under the new config (305 files, whitespace-only)
- Add `#[macro_use] extern crate tracing` to provider lib.rs; replace 9 `tracing::warn!` / `tracing::debug!` call sites with bare macro names

