### PR TITLE
feat: exact Trx parsing/formatting, alloy-style helpers, bump 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-10
+
+### Added
+
+- Exact decimal parsing via `FromStr` / `parse_trx` and fixed-precision
+  formatting via `format_trx`. Their syntax and 6-decimal behavior mirror
+  alloy's unit helpers while rejecting negative values and amounts above
+  `i64::MAX` sun.
+
+### Changed (Breaking)
+
+- Removed the floating-point `Trx::from_trx(f64)` and `Trx::as_trx()` methods,
+  along with `AmountError::OutOfRange`; use exact string parsing,
+  `format_trx`, or raw sun access instead.
+- `Trx` display output is now exact and fixed to 6 fractional digits without a
+  `TRX` suffix (`1.500000` instead of the lossy `1.5 TRX`).
+- `Trx` addition and subtraction now panic on overflow, negative operands, or a
+  negative result instead of using signed saturating arithmetic. The checked
+  variants return `None` for the same invalid cases.
+
 ## [0.2.2] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3433,7 +3433,7 @@ dependencies = [
 
 [[package]]
 name = "tronz"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "tronz-contract",
  "tronz-primitives",
@@ -3444,7 +3444,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-contract"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-json-abi",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-primitives"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-primitives",
  "bs58",
@@ -3473,7 +3473,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-provider"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "fastrand",
  "futures",
@@ -3493,7 +3493,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-signer"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aes",
  "coins-bip32",
@@ -3515,7 +3515,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-signer-aws"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-kms",
@@ -3531,7 +3531,7 @@ dependencies = [
 
 [[package]]
 name = "tronz-sol-macro"
-version = "0.2.2"
+version = "0.3.0"
 dependencies = [
  "alloy-json-abi",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members  = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version      = "0.2.2"
+version      = "0.3.0"
 edition      = "2024"
 rust-version = "1.85"
 license      = "MIT OR Apache-2.0"
@@ -12,12 +12,12 @@ readme       = "README.md"
 
 [workspace.dependencies]
 # internal
-tronz-primitives  = { path = "crates/primitives",  version = "0.2.2", default-features = false }
-tronz-signer      = { path = "crates/signer",      version = "0.2.2", default-features = false }
-tronz-signer-aws  = { path = "crates/signer-aws",  version = "0.2.2", default-features = false }
-tronz-provider    = { path = "crates/provider",    version = "0.2.2", default-features = false }
-tronz-contract    = { path = "crates/contract",    version = "0.2.2", default-features = false }
-tronz-sol-macro   = { path = "crates/sol-macro",   version = "0.2.2" }
+tronz-primitives  = { path = "crates/primitives",  version = "0.3.0", default-features = false }
+tronz-signer      = { path = "crates/signer",      version = "0.3.0", default-features = false }
+tronz-signer-aws  = { path = "crates/signer-aws",  version = "0.3.0", default-features = false }
+tronz-provider    = { path = "crates/provider",    version = "0.3.0", default-features = false }
+tronz-contract    = { path = "crates/contract",    version = "0.3.0", default-features = false }
+tronz-sol-macro   = { path = "crates/sol-macro",   version = "0.3.0" }
 
 # alloy (reused directly)
 alloy-primitives = { version = "1", default-features = false, features = ["std", "serde"] }

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Or add it to your `Cargo.toml` manually:
 
 ```toml
 [dependencies]
-tronz = "0.2"
+tronz = "0.3"
 ```
 
 Optional features:
@@ -127,7 +127,7 @@ async fn main() -> anyhow::Result<()> {
 ### Stake TRX and delegate energy
 
 ```rust,no_run
-use tronz::{LocalSigner, ProviderBuilder, TronProvider, Trx, ResourceCode, TRONGRID_NILE};
+use tronz::{LocalSigner, ProviderBuilder, TronProvider, ResourceCode, TRONGRID_NILE, parse_trx};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -143,7 +143,7 @@ async fn main() -> anyhow::Result<()> {
     // Freeze 100 TRX for energy
     provider
         .freeze_balance()
-        .amount(Trx::from_trx(100)?)
+        .amount(parse_trx("100")?)
         .resource(ResourceCode::Energy)
         .send()
         .await?
@@ -154,7 +154,7 @@ async fn main() -> anyhow::Result<()> {
     provider
         .delegate_resource()
         .resource(ResourceCode::Energy)
-        .amount(Trx::from_trx(100)?)
+        .amount(parse_trx("100")?)
         .to(receiver)
         .send()
         .await?

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -17,6 +17,8 @@ use crate::error::{ContractError, Result};
 /// Optionally attach TRX or TRC10 tokens before executing:
 ///
 /// ```ignore
+/// use tronz_primitives::parse_trx;
+///
 /// // Read-only simulation (trigger_constant_contract)
 /// let output = contract.call_raw(calldata).call().await?;
 ///
@@ -26,7 +28,7 @@ use crate::error::{ContractError, Result};
 /// // Payable call — send 1 TRX alongside
 /// let pending = contract
 ///     .call_raw(calldata)
-///     .value(Trx::from_sun_unchecked(1_000_000))
+///     .value(parse_trx("1")?)
 ///     .send()
 ///     .await?;
 /// ```

--- a/crates/primitives/src/amount.rs
+++ b/crates/primitives/src/amount.rs
@@ -6,16 +6,24 @@
 use core::{
     fmt,
     ops::{Add, Sub},
+    str::FromStr,
 };
 
 use serde::{Deserialize, Serialize};
 
 use crate::error::AmountError;
 
+/// Maximum sun value that fits in TRON's signed 64-bit amount fields.
+const MAX_SUN: u64 = i64::MAX as u64;
+
 /// Number of sun in one TRX.
 pub const SUN_PER_TRX: i64 = 1_000_000;
 
 /// An amount of TRX, stored internally as `i64` sun.
+///
+/// User-facing constructors enforce non-negative amounts. Negative values remain
+/// representable only so malformed protobuf or serialized data can be inspected
+/// and round-tripped without panicking; arithmetic operations reject them.
 #[derive(Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Default, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Trx(i64);
@@ -26,34 +34,21 @@ impl Trx {
 
     /// Construct directly from a sun value without validation.
     ///
-    /// Negative values are representable here because malformed on-chain data
-    /// must round-trip without panicking; prefer [`Trx::from_sun`] for
-    /// user-facing input.
+    /// This bypasses the non-negative amount invariant. It exists for protobuf
+    /// round-tripping and malformed on-chain data handling; do not use it for
+    /// user input, balances, transfers, or contract calls. Prefer
+    /// [`Trx::from_sun`] for raw user-facing input.
+    #[doc(hidden)]
     pub const fn from_sun_unchecked(sun: i64) -> Self {
         Self(sun)
     }
 
-    /// Construct from a sun value, rejecting negatives.
-    pub fn from_sun(sun: i64) -> Result<Self, AmountError> {
+    /// Construct from a raw sun value, rejecting negatives.
+    pub const fn from_sun(sun: i64) -> Result<Self, AmountError> {
         if sun < 0 {
             return Err(AmountError::Negative(sun));
         }
         Ok(Self(sun))
-    }
-
-    /// Construct from a floating-point TRX value (e.g. `1.5` TRX).
-    ///
-    /// Rejects negative and non-finite values, and values that overflow the
-    /// `i64` sun range.
-    pub fn from_trx(trx: f64) -> Result<Self, AmountError> {
-        if !trx.is_finite() || trx < 0.0 {
-            return Err(AmountError::OutOfRange(trx));
-        }
-        let sun = trx * SUN_PER_TRX as f64;
-        if sun > i64::MAX as f64 {
-            return Err(AmountError::OutOfRange(trx));
-        }
-        Ok(Self(sun.round() as i64))
     }
 
     /// The raw sun value.
@@ -61,39 +56,161 @@ impl Trx {
         self.0
     }
 
-    /// The value expressed as floating-point TRX (lossy for large amounts).
-    pub fn as_trx(self) -> f64 {
-        self.0 as f64 / SUN_PER_TRX as f64
-    }
-
-    /// Checked addition, returning `None` on `i64` overflow.
+    /// Checked addition. Returns `None` on `i64` overflow or if either operand
+    /// is negative.
     pub fn checked_add(self, rhs: Trx) -> Option<Trx> {
-        self.0.checked_add(rhs.0).map(Trx)
+        if self.0 < 0 || rhs.0 < 0 {
+            return None;
+        }
+        self.0.checked_add(rhs.0).filter(|&v| v >= 0).map(Trx)
     }
 
-    /// Checked subtraction, returning `None` on `i64` overflow.
+    /// Checked subtraction. Returns `None` on `i64` overflow, if either operand
+    /// is negative, or if the result would be negative.
     pub fn checked_sub(self, rhs: Trx) -> Option<Trx> {
-        self.0.checked_sub(rhs.0).map(Trx)
+        if self.0 < 0 || rhs.0 < 0 {
+            return None;
+        }
+        self.0.checked_sub(rhs.0).filter(|&v| v >= 0).map(Trx)
     }
+}
+
+/// Parse a decimal TRX string (e.g. `"1.5"` or `"100"`) into sun.
+///
+/// The accepted syntax mirrors alloy's `parse_units` with 6 decimal places:
+/// leading decimal points and `_` separators are accepted, an empty string is
+/// zero, and fractional digits beyond sun precision are truncated. Negative
+/// values remain invalid because native TRX amounts are non-negative.
+///
+/// # Examples
+///
+/// ```
+/// use tronz_primitives::Trx;
+///
+/// assert_eq!("1".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+/// assert_eq!("1.5".parse::<Trx>().unwrap().as_sun(), 1_500_000);
+/// assert_eq!(".5".parse::<Trx>().unwrap().as_sun(), 500_000);
+/// assert_eq!("0.000001".parse::<Trx>().unwrap().as_sun(), 1);
+/// assert_eq!("1.0000009".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+/// assert!("-1".parse::<Trx>().is_err());
+/// ```
+impl FromStr for Trx {
+    type Err = AmountError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if s.starts_with('-') || !s.is_ascii() {
+            return Err(AmountError::ParseError(s.to_owned()));
+        }
+
+        let mut normalized = s.to_owned();
+        let decimal_len = if let Some(decimal_index) = normalized.find('.') {
+            normalized.remove(decimal_index);
+            normalized[decimal_index..].len()
+        } else {
+            0
+        };
+
+        // Match alloy's `parse_units`: discard fractional digits beyond the
+        // selected unit precision rather than rounding or returning an error.
+        if decimal_len > 6 {
+            normalized.truncate(normalized.len() - (decimal_len - 6));
+        }
+
+        let mut value = 0u64;
+        for byte in normalized.bytes() {
+            if byte == b'_' {
+                continue;
+            }
+            let digit = match byte {
+                b'0'..=b'9' => (byte - b'0') as u64,
+                _ => return Err(AmountError::ParseError(s.to_owned())),
+            };
+            value = value
+                .checked_mul(10)
+                .and_then(|v| v.checked_add(digit))
+                .ok_or_else(|| AmountError::ParseError(s.to_owned()))?;
+        }
+
+        let scale = 6usize.saturating_sub(decimal_len);
+        let value = value
+            .checked_mul(10u64.pow(scale as u32))
+            .filter(|&v| v <= MAX_SUN)
+            .ok_or_else(|| AmountError::ParseError(s.to_owned()))?;
+        Ok(Self(value as i64))
+    }
+}
+
+/// Parse a decimal TRX string into a [`Trx`] amount.
+///
+/// Free-function alias for [`str::parse::<Trx>()`](Trx::from_str), mirroring
+/// alloy's [`parse_ether`](https://docs.rs/alloy-primitives/latest/alloy_primitives/utils/fn.parse_ether.html)
+/// for callers who prefer that style.
+///
+/// ```
+/// use tronz_primitives::parse_trx;
+///
+/// assert_eq!(parse_trx("1.5").unwrap().as_sun(), 1_500_000);
+/// ```
+pub fn parse_trx(s: &str) -> Result<Trx, AmountError> {
+    s.parse()
+}
+
+/// Format a [`Trx`] amount as a decimal string with exactly 6 fractional digits.
+///
+/// Free-function alias for [`Trx`]'s [`Display`](fmt::Display), mirroring alloy's
+/// [`format_ether`](https://docs.rs/alloy-primitives/latest/alloy_primitives/utils/fn.format_ether.html).
+///
+/// ```
+/// use tronz_primitives::{Trx, format_trx};
+///
+/// let amount = Trx::from_sun(1_500_000).unwrap();
+/// assert_eq!(format_trx(amount), "1.500000");
+/// ```
+pub fn format_trx(amount: Trx) -> String {
+    amount.to_string()
 }
 
 impl Add for Trx {
     type Output = Trx;
+    /// # Panics
+    ///
+    /// Panics on `i64` overflow or a negative result. Use
+    /// [`Trx::checked_add`] for a non-panicking alternative.
     fn add(self, rhs: Trx) -> Trx {
-        Trx(self.0.saturating_add(rhs.0))
+        self.checked_add(rhs).expect("TRX addition overflows or contains a negative operand")
     }
 }
 
 impl Sub for Trx {
     type Output = Trx;
+    /// # Panics
+    ///
+    /// Panics on `i64` overflow or a negative result. Use
+    /// [`Trx::checked_sub`] for a non-panicking alternative.
     fn sub(self, rhs: Trx) -> Trx {
-        Trx(self.0.saturating_sub(rhs.0))
+        self.checked_sub(rhs)
+            .expect("TRX subtraction underflows, overflows, or contains a negative operand")
     }
 }
 
+/// Formats the amount as a fixed-precision decimal TRX string, exactly (no
+/// `f64`), mirroring alloy's `format_units` behavior.
+///
+/// ```
+/// use tronz_primitives::Trx;
+///
+/// assert_eq!(Trx::from_sun(1_500_000).unwrap().to_string(), "1.500000");
+/// assert_eq!("100".parse::<Trx>().unwrap().to_string(), "100.000000");
+/// assert_eq!(Trx::from_sun(1).unwrap().to_string(), "0.000001");
+/// assert_eq!("1.5".parse::<Trx>().unwrap().to_string(), "1.500000");
+/// ```
 impl fmt::Display for Trx {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} TRX", self.as_trx())
+        let abs = self.0.unsigned_abs();
+        let whole = abs / SUN_PER_TRX as u64;
+        let frac = abs % SUN_PER_TRX as u64;
+        let sign = if self.0 < 0 { "-" } else { "" };
+        write!(f, "{sign}{whole}.{frac:06}")
     }
 }
 
@@ -107,18 +224,20 @@ impl fmt::Debug for Trx {
 mod tests {
     use super::*;
 
+    fn sun(value: i64) -> Trx {
+        Trx::from_sun(value).unwrap()
+    }
+
     #[test]
     fn conversions() {
-        assert_eq!(Trx::from_trx(1.0).unwrap().as_sun(), 1_000_000);
-        assert_eq!(Trx::from_trx(1.5).unwrap().as_sun(), 1_500_000);
-        assert_eq!(Trx::from_sun(2_500_000).unwrap().as_trx(), 2.5);
+        assert_eq!("1".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+        assert_eq!("1.5".parse::<Trx>().unwrap().as_sun(), 1_500_000);
     }
 
     #[test]
     fn rejects_negative() {
         assert!(Trx::from_sun(-1).is_err());
-        assert!(Trx::from_trx(-1.0).is_err());
-        assert!(Trx::from_trx(f64::NAN).is_err());
+        assert!("-1".parse::<Trx>().is_err());
     }
 
     #[test]
@@ -128,10 +247,101 @@ mod tests {
 
     #[test]
     fn arithmetic() {
-        let a = Trx::from_trx(1.0).unwrap();
-        let b = Trx::from_trx(0.5).unwrap();
+        let a = "1".parse::<Trx>().unwrap();
+        let b = "0.5".parse::<Trx>().unwrap();
         assert_eq!((a + b).as_sun(), 1_500_000);
         assert_eq!((a - b).as_sun(), 500_000);
         assert_eq!(a.checked_add(b), Some(Trx::from_sun(1_500_000).unwrap()));
+    }
+
+    #[test]
+    fn parse_valid() {
+        assert_eq!("1".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+        assert_eq!("1.5".parse::<Trx>().unwrap().as_sun(), 1_500_000);
+        assert_eq!(".5".parse::<Trx>().unwrap().as_sun(), 500_000);
+        assert_eq!("0.000001".parse::<Trx>().unwrap().as_sun(), 1);
+        assert_eq!("100".parse::<Trx>().unwrap().as_sun(), 100_000_000);
+        assert_eq!("1.000000".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+        assert_eq!("1_000".parse::<Trx>().unwrap().as_sun(), 1_000_000_000);
+        assert_eq!("1.".parse::<Trx>().unwrap().as_sun(), 1_000_000);
+        assert_eq!("".parse::<Trx>().unwrap(), Trx::ZERO);
+    }
+
+    #[test]
+    fn parse_invalid() {
+        assert!("-1".parse::<Trx>().is_err());
+        assert!("abc".parse::<Trx>().is_err());
+        assert!("1.abc".parse::<Trx>().is_err());
+        assert!(" 1 ".parse::<Trx>().is_err());
+        assert!("+1".parse::<Trx>().is_err());
+        assert!("1.金额".parse::<Trx>().is_err());
+    }
+
+    #[test]
+    fn parse_truncates_beyond_sun_precision() {
+        assert_eq!("1.1234567".parse::<Trx>().unwrap().as_sun(), 1_123_456);
+        assert_eq!("0.0000009".parse::<Trx>().unwrap(), Trx::ZERO);
+    }
+
+    #[test]
+    fn display_is_exact() {
+        assert_eq!(sun(1_500_000).to_string(), "1.500000");
+        assert_eq!("100".parse::<Trx>().unwrap().to_string(), "100.000000");
+        assert_eq!(sun(1).to_string(), "0.000001");
+        assert_eq!(Trx::ZERO.to_string(), "0.000000");
+        assert_eq!(Trx::from_sun_unchecked(-1_500_000).to_string(), "-1.500000");
+    }
+
+    #[test]
+    fn display_parse_round_trip() {
+        for &sun in &[0, 1, 1_000_000, 1_500_000, 100_000_000, 123_456] {
+            let t = Trx::from_sun(sun).unwrap();
+            assert_eq!(t.to_string().parse::<Trx>().unwrap(), t);
+        }
+    }
+
+    #[test]
+    fn alloy_style_helpers() {
+        assert_eq!(parse_trx("1.5").unwrap().as_sun(), 1_500_000);
+        assert_eq!(format_trx(sun(1_500_000)), "1.500000");
+    }
+
+    #[test]
+    fn matches_alloy_unit_helpers_within_tron_range() {
+        for input in ["", ".5", "1.", "1_000", "1.1234567", "9223372036854.775807"] {
+            let alloy = alloy_primitives::utils::parse_units(input, 6).unwrap();
+            let expected = u64::try_from(alloy).unwrap();
+            assert_eq!(input.parse::<Trx>().unwrap().as_sun(), expected as i64);
+        }
+
+        for amount in [Trx::ZERO, sun(1), sun(1_500_000), "100".parse().unwrap()] {
+            let alloy = alloy_primitives::utils::format_units(amount.as_sun(), 6).unwrap();
+            assert_eq!(amount.to_string(), alloy);
+        }
+    }
+
+    #[test]
+    fn parse_accepts_max_i64_sun() {
+        let max = "9223372036854.775807".parse::<Trx>().unwrap();
+        assert_eq!(max.as_sun(), i64::MAX);
+    }
+
+    #[test]
+    fn parse_rejects_above_max_i64_sun() {
+        assert!("9223372036854.775808".parse::<Trx>().is_err());
+    }
+
+    #[test]
+    fn checked_sub_rejects_negative() {
+        assert!(Trx::ZERO.checked_sub(sun(1)).is_none());
+    }
+
+    #[test]
+    fn checked_arithmetic_rejects_negative_operands() {
+        let negative = Trx::from_sun_unchecked(-5);
+        assert!(sun(10).checked_add(negative).is_none());
+        assert!(negative.checked_add(sun(10)).is_none());
+        assert!(sun(10).checked_sub(negative).is_none());
+        assert!(negative.checked_sub(sun(10)).is_none());
     }
 }

--- a/crates/primitives/src/error.rs
+++ b/crates/primitives/src/error.rs
@@ -34,9 +34,9 @@ pub enum AmountError {
     #[error("negative amount is invalid: {0} sun")]
     Negative(i64),
 
-    /// Converting a floating-point TRX value overflowed the `i64` sun range.
-    #[error("amount out of range: {0} TRX cannot be represented in sun")]
-    OutOfRange(f64),
+    /// The string did not contain a valid decimal TRX amount.
+    #[error("invalid TRX amount: {0:?}")]
+    ParseError(String),
 }
 
 /// Errors produced when constructing a [`RecoverableSignature`](crate::RecoverableSignature).

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -13,7 +13,7 @@ mod signature;
 pub use address::{ADDRESS_LEN, ADDRESS_PREFIX, Address, EVM_ADDRESS_LEN};
 /// Types re-used directly from `alloy-primitives`.
 pub use alloy_primitives::{B256, Bytes, U256, keccak256};
-pub use amount::{SUN_PER_TRX, Trx};
+pub use amount::{SUN_PER_TRX, Trx, format_trx, parse_trx};
 pub use error::{AddressError, AmountError, SignatureError};
 pub use resource::ResourceCode;
 pub use signature::{RecoverableSignature, SIGNATURE_LEN};

--- a/crates/provider/src/provider/builder.rs
+++ b/crates/provider/src/provider/builder.rs
@@ -101,7 +101,7 @@ impl<F: TxFiller> ProviderBuilder<F> {
     /// Add both the TAPOS filler and a 20 TRX default fee-limit filler in one
     /// call — the most common setup for a read/write provider.
     ///
-    /// Equivalent to `.with_tapos().with_fee_limit(Trx::from_sun_unchecked(20_000_000))`.
+    /// Equivalent to `.with_tapos().with_fee_limit(Trx::from_sun(20_000_000).unwrap())`.
     pub fn with_recommended_fillers(
         self,
     ) -> ProviderBuilder<JoinFill<JoinFill<F, TaposFiller>, FeeLimitFiller>> {

--- a/crates/tronz/README.md
+++ b/crates/tronz/README.md
@@ -15,7 +15,7 @@ cargo add tronz --features full
 Or in your `Cargo.toml`:
 
 ```toml
-tronz = { version = "0.2", features = ["full"] }
+tronz = { version = "0.3", features = ["full"] }
 ```
 
 A full list of available features can be found in the
@@ -40,7 +40,7 @@ println!("Latest block: {} ({}ms)", block.number, block.timestamp);
 ### Sending TRX
 
 ```rust,no_run
-use tronz::{LocalSigner, ProviderBuilder, TronProvider, TronSigner, Trx, TRONGRID_NILE};
+use tronz::{LocalSigner, ProviderBuilder, TronProvider, TronSigner, TRONGRID_NILE, parse_trx};
 
 # async fn example() -> Result<(), Box<dyn std::error::Error>> {
 let signer = LocalSigner::from_hex("PRIVATE_KEY_HEX").expect("valid key");
@@ -55,7 +55,7 @@ let provider = ProviderBuilder::new()
 let pending = provider
     .send_trx()
     .to(from)
-    .amount(Trx::from_sun_unchecked(1_000_000))
+    .amount(parse_trx("1")?)
     .send()
     .await?;
 

--- a/crates/tronz/src/lib.rs
+++ b/crates/tronz/src/lib.rs
@@ -7,7 +7,7 @@
 /* --------------------------------- Primitives --------------------------------- */
 
 #[doc(no_inline)]
-pub use primitives::{Address, Trx, U256};
+pub use primitives::{Address, ResourceCode, Trx, U256, format_trx, parse_trx};
 /// Core TRON primitives: addresses, amounts, resource codes, signatures.
 #[doc(inline)]
 pub use tronz_primitives as primitives;


### PR DESCRIPTION
### Added

- Exact decimal parsing via `FromStr` / `parse_trx` and fixed-precision
  formatting via `format_trx`. Their syntax and 6-decimal behavior mirror
  alloy's unit helpers while rejecting negative values and amounts above
  `i64::MAX` sun.

### Changed (Breaking)

- Removed the floating-point `Trx::from_trx(f64)` and `Trx::as_trx()` methods,
  along with `AmountError::OutOfRange`; use exact string parsing,
  `format_trx`, or raw sun access instead.

- `Trx` display output is now exact and fixed to 6 fractional digits without a
  `TRX` suffix (`1.500000` instead of the lossy `1.5 TRX`).

- `Trx` addition and subtraction now panic on overflow, negative operands, or a
  negative result instead of using signed saturating arithmetic. The checked
  variants return `None` for the same invalid cases.