### PR TITLE
release: v0.4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         rust:
           - "stable"
           - "nightly"
-          - "1.85" # MSRV
+          - "1.91.1" # MSRV
         flags:
           # No TLS (plain HTTP/2 transport only)
           - "--no-default-features --features provider-grpc,contract"
@@ -38,7 +38,7 @@ jobs:
           - "--all-features"
         exclude:
           # Skip --all-features on MSRV to keep the matrix lean
-          - rust: "1.85" # MSRV
+          - rust: "1.91.1" # MSRV
             flags: "--all-features"
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -56,15 +56,15 @@ jobs:
           cache-on-failure: true
       # MSRV: only build, do not run tests (nextest requires a newer Rust)
       - name: build (MSRV)
-        if: ${{ matrix.rust == '1.85' }}
+        if: ${{ matrix.rust == '1.91.1' }}
         run: cargo build --workspace ${{ matrix.flags }}
       - name: Install cargo-nextest
-        if: ${{ matrix.rust != '1.85' }}
+        if: ${{ matrix.rust != '1.91.1' }}
         uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
           tool: nextest
       - name: test
-        if: ${{ matrix.rust != '1.85' }}
+        if: ${{ matrix.rust != '1.91.1' }}
         run: cargo nextest run --workspace ${{ matrix.flags }}
 
   doctest:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,51 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- New `tronz-abi` crate with a protobuf-independent `TronAbi` metadata model,
+  forward-compatible unknown enum values, optional serde support, and an
+  optional Alloy `JsonAbi` bridge.
+- `DeployBuilder::tron_abi` for deploying with native TRON ABI metadata while
+  `DeployBuilder::abi` continues to accept Alloy's `JsonAbi`.
+
+### Changed (Breaking)
+
+- The minimum supported Rust version is now 1.91.1, matching the current tonic
+  and AWS SDK dependency requirements.
+- `ConstantCallResult::output` now uses reference-counted `Bytes` instead of
+  `Vec<u8>` to avoid copying contract return data.
+- Transaction memos now use reference-counted `Bytes` throughout
+  `TransactionRequest` and every transaction builder.
+- Market order IDs now use the fixed-size `B256` type in contracts, query APIs,
+  builders, and returned order metadata instead of unchecked byte vectors.
+- Low-level contract deployment and metadata APIs now use native `TronAbi`
+  instead of JSON-encoded `Vec<u8>` values. Alloy `JsonAbi` conversion lives in
+  `tronz-abi` behind its `alloy` feature.
+- `ProviderBuilder::with_recommended_fillers()` no longer installs
+  `TaposFiller`: every currently supported transaction is constructed by a
+  node endpoint that already fills TAPOS. Explicit `.with_tapos()` remains
+  available and its fields are now applied to the returned transaction.
+
+### Performance
+
+- Block-summary RPCs now use wire-compatible lightweight protobuf responses
+  that skip transaction payloads when only block number, timestamp, and hash
+  are requested.
+- High-volume protobuf fields such as calldata, bytecode, log data, constant
+  results, transaction memo data, and signatures now use reference-counted
+  `bytes::Bytes` across the tonic boundary.
+- Concurrent `TaposFiller` cache misses are coalesced into one
+  `get_now_block` request.
+
+### Fixed
+
+- Contract deployment now includes the supplied ABI in the TRON protobuf
+  request instead of silently sending `abi: None`.
+- Contract ABI responses are preserved exactly as `TronAbi`, including bare
+  tuples and unknown protobuf enum values, instead of being replaced with an
+  empty byte array or making the entire contract query fail.
+
 ## [0.3.0] - 2026-07-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3435,11 +3435,22 @@ dependencies = [
 name = "tronz"
 version = "0.3.0"
 dependencies = [
+ "tronz-abi",
  "tronz-contract",
  "tronz-primitives",
  "tronz-provider",
  "tronz-signer",
  "tronz-signer-aws",
+]
+
+[[package]]
+name = "tronz-abi"
+version = "0.3.0"
+dependencies = [
+ "alloy-json-abi",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -3454,6 +3465,7 @@ dependencies = [
  "hex",
  "thiserror 2.0.18",
  "tokio",
+ "tronz-abi",
  "tronz-primitives",
  "tronz-provider",
  "tronz-sol-macro",
@@ -3479,7 +3491,6 @@ dependencies = [
  "futures",
  "prost",
  "prost-types",
- "serde_json",
  "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
@@ -3487,6 +3498,7 @@ dependencies = [
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
+ "tronz-abi",
  "tronz-primitives",
  "tronz-signer",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version      = "0.3.0"
 edition      = "2024"
-rust-version = "1.85"
+rust-version = "1.91.1"
 license      = "MIT OR Apache-2.0"
 repository   = "https://github.com/throgxyz/tronz"
 readme       = "README.md"
@@ -13,6 +13,7 @@ readme       = "README.md"
 [workspace.dependencies]
 # internal
 tronz-primitives  = { path = "crates/primitives",  version = "0.3.0", default-features = false }
+tronz-abi         = { path = "crates/abi",         version = "0.3.0", default-features = false }
 tronz-signer      = { path = "crates/signer",      version = "0.3.0", default-features = false }
 tronz-signer-aws  = { path = "crates/signer-aws",  version = "0.3.0", default-features = false }
 tronz-provider    = { path = "crates/provider",    version = "0.3.0", default-features = false }
@@ -58,7 +59,7 @@ tonic       = { version = "0.14", default-features = false, features = ["transpo
 tonic-prost = { version = "0.14" }
 
 # async
-tokio   = { version = "1", features = ["rt", "rt-multi-thread", "macros", "time"] }
+tokio   = { version = "1", features = ["rt", "rt-multi-thread", "macros", "sync", "time"] }
 futures = { version = "0.3" }
 
 # serde

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An idiomatic, async-first Rust SDK for the [TRON](https://tron.network) network 
 [![Crates.io](https://img.shields.io/crates/v/tronz.svg)](https://crates.io/crates/tronz)
 [![docs.rs](https://docs.rs/tronz/badge.svg)](https://docs.rs/tronz)
 [![License: MIT / Apache-2.0](https://img.shields.io/badge/license-MIT%20%2F%20Apache--2.0-blue.svg)](#license)
-[![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
+[![Rust 1.91.1+](https://img.shields.io/badge/rust-1.91.1%2B-orange.svg)](https://www.rust-lang.org)
 [![CI](https://github.com/throgxyz/tronz/actions/workflows/ci.yml/badge.svg)](https://github.com/throgxyz/tronz/actions/workflows/ci.yml)
 
 ## Features
@@ -14,7 +14,7 @@ An idiomatic, async-first Rust SDK for the [TRON](https://tron.network) network 
 - **Resilient by default** — per-call timeouts plus automatic retries with exponential back-off and jitter, configurable via `ProviderBuilder` / `GrpcTransport::builder()`
 - **Failover** — load-balance and fail over across multiple equivalent endpoints (`with_endpoints`, tonic `balance_list`)
 - **Typed provider** — fluent builder API for every native contract operation
-- **Filler chain** — automatic TAPOS, fee-limit, and signing (mirrors alloy's `JoinFill`)
+- **Filler chain** — automatic fee-limit and signing, plus optional explicit TAPOS overrides (mirrors alloy's `JoinFill`)
 - **TRX / TRC10 / TRC20** — transfers, balance queries, and token metadata
 - **Staking** — Stake 2.0 (freeze, unfreeze, delegate, undelegate, claim rewards) and Stake 1.0 legacy (`freeze_balance_v1`, `unfreeze_balance_v1`)
 - **HD wallets** — BIP-39 mnemonic generation and BIP-44 key derivation (`signer-mnemonic` feature, TRON coin type 195)
@@ -22,7 +22,7 @@ An idiomatic, async-first Rust SDK for the [TRON](https://tron.network) network 
 - **AWS KMS** — sign with a key that never leaves the HSM (`signer-aws` feature, `AwsSigner`)
 - **`tron_sol!` macro** — type-safe contract bindings with typed call/event builders and JSON ABI file path support (superset of alloy's `sol!`)
 - **TRC721** — `Trc721Instance`: `transfer_from`, `approve`, `owner_of`, `token_uri`, and standard ERC-721 queries
-- **Contract deploy & call** — `DeployBuilder`, `CallBuilder`, dynamic ABI, energy estimation
+- **Contract deploy & call** — native `TronAbi` metadata with an Alloy `JsonAbi` bridge, `DeployBuilder`, dynamic calls, and energy estimation
 - **Event decoding** — decode and filter logs with `SolEvent`
 - **Votes & account management** — SR voting, account activation, name and permission updates
 - **Super representatives** — `WitnessApi`: become SR, update URL, update brokerage ratio
@@ -264,6 +264,7 @@ async fn main() -> anyhow::Result<()> {
 |---|---|
 | [`tronz`](https://crates.io/crates/tronz) | Meta-crate — re-exports everything |
 | [`tronz-primitives`](https://crates.io/crates/tronz-primitives) | `Address`, `Trx`, `ResourceCode`, `RecoverableSignature` |
+| [`tronz-abi`](https://crates.io/crates/tronz-abi) | Native TRON ABI metadata and optional Alloy `JsonAbi` conversion |
 | [`tronz-signer`](https://crates.io/crates/tronz-signer) | `TronSigner` trait and `LocalSigner` (in-memory secp256k1) |
 | [`tronz-provider`](https://crates.io/crates/tronz-provider) | gRPC transport, provider, fillers, domain types, extension traits |
 | [`tronz-contract`](https://crates.io/crates/tronz-contract) | `ContractInstance`, `DeployBuilder`, TRC20 bindings, event decoding |
@@ -327,7 +328,7 @@ use tronz::{TRONGRID_MAINNET, TRONGRID_NILE};
 
 ## Minimum Supported Rust Version
 
-**1.85** (Rust 2024 edition, required for stable RPITIT).
+**1.91.1** (Rust 2024 edition).
 
 ## License
 

--- a/crates/abi/Cargo.toml
+++ b/crates/abi/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name         = "tronz-abi"
+description  = "TRON contract ABI metadata types and optional Alloy JSON ABI conversion."
+keywords     = ["tron", "blockchain", "abi", "solidity", "smart-contracts"]
+categories   = ["cryptography::cryptocurrencies", "data-structures"]
+version      = { workspace = true }
+edition      = { workspace = true }
+rust-version = { workspace = true }
+license      = { workspace = true }
+repository   = { workspace = true }
+
+[dependencies]
+alloy-json-abi = { workspace = true, optional = true }
+serde          = { workspace = true, optional = true }
+thiserror      = { workspace = true }
+
+[features]
+default = []
+alloy = ["dep:alloy-json-abi"]
+serde = ["dep:serde"]
+
+[dev-dependencies]
+serde_json = { workspace = true }

--- a/crates/abi/README.md
+++ b/crates/abi/README.md
@@ -13,6 +13,20 @@ model without leaking generated protobuf types:
 - `TronAbiEntryType`
 - `TronAbiStateMutability`
 
+## Serialization formats
+
+The `serde` feature serializes the native `TronAbi` data model. Its JSON shape
+is intended for persisting TRON metadata and is **not** the standard Solidity
+JSON ABI array format. Parse a standard JSON ABI as Alloy's `JsonAbi`, then
+convert it explicitly:
+
+```rust,ignore
+use tronz_abi::{JsonAbi, TronAbi};
+
+let json_abi: JsonAbi = serde_json::from_str(ABI_JSON)?;
+let tron_abi = TronAbi::try_from(&json_abi)?;
+```
+
 Enable the `alloy` feature to convert between `TronAbi` and Alloy's `JsonAbi`:
 
 ```rust,ignore
@@ -34,6 +48,13 @@ metadata in the other direction fails when it contains a bare `tuple` without
 recoverable component types. `JsonAbi` also groups items by kind and name, so
 top-level entry order is not preserved across conversion. The native protobuf
 conversion preserves the metadata and ordering returned by the node.
+
+Converting `TronAbi` to `JsonAbi` normalizes each entry to the fields supported
+by its Solidity JSON ABI item kind. TRON metadata fields that have no meaning
+for that item kind, such as outputs on an event or `anonymous` on a function,
+are ignored. Conversion still fails when a value cannot be represented safely,
+including unknown entry kinds, invalid identifiers or types, bare tuples, and
+duplicate singleton entries.
 
 ## License
 

--- a/crates/abi/README.md
+++ b/crates/abi/README.md
@@ -1,0 +1,41 @@
+# tronz-abi
+
+Native TRON smart-contract ABI metadata types for the
+[tronz](https://github.com/throgxyz/tronz) SDK.
+
+TRON nodes store contract ABI metadata in a protobuf-specific entry model,
+which is not identical to the Solidity JSON ABI format. This crate exposes that
+model without leaking generated protobuf types:
+
+- `TronAbi`
+- `TronAbiEntry`
+- `TronAbiParam`
+- `TronAbiEntryType`
+- `TronAbiStateMutability`
+
+Enable the `alloy` feature to convert between `TronAbi` and Alloy's `JsonAbi`:
+
+```rust,ignore
+use tronz_abi::{JsonAbi, TronAbi};
+
+let json_abi = JsonAbi::new();
+let tron_abi = TronAbi::try_from(&json_abi)?;
+let json_abi = JsonAbi::try_from(&tron_abi)?;
+```
+
+The equivalent `try_from_json_abi` and `try_to_json_abi` convenience methods
+are also available. The complete `alloy-json-abi` API is re-exported as
+`tronz_abi::json_abi`, so applications can use matching `Param`, `Function`,
+and `Event` types without adding another direct dependency.
+
+`JsonAbi` to `TronAbi` conversion preserves canonical tuple component types,
+but cannot preserve component names or `internalType` values. Converting node
+metadata in the other direction fails when it contains a bare `tuple` without
+recoverable component types. `JsonAbi` also groups items by kind and name, so
+top-level entry order is not preserved across conversion. The native protobuf
+conversion preserves the metadata and ordering returned by the node.
+
+## License
+
+Licensed under either of [Apache License, Version 2.0](../../LICENSE-APACHE) or
+[MIT license](../../LICENSE-MIT) at your option.

--- a/crates/abi/src/abi.rs
+++ b/crates/abi/src/abi.rs
@@ -1,0 +1,146 @@
+use std::{slice, vec};
+
+use crate::TronAbiEntry;
+
+/// TRON's native contract ABI metadata.
+///
+/// Unlike a Solidity JSON ABI, this representation mirrors the information a
+/// TRON node stores and returns without exposing generated protobuf types.
+/// Entries remain in node-provided order, including unknown entry kinds.
+///
+/// # Examples
+///
+/// ```
+/// use tronz_abi::{
+///     TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiParam, TronAbiStateMutability,
+/// };
+///
+/// let transfer = TronAbiEntry {
+///     entry_type: TronAbiEntryType::Function,
+///     name: "transfer".into(),
+///     inputs: vec![TronAbiParam::new("to", "address"), TronAbiParam::new("amount", "uint256")],
+///     outputs: vec![TronAbiParam::new("", "bool")],
+///     state_mutability: TronAbiStateMutability::NonPayable,
+///     ..Default::default()
+/// };
+///
+/// let abi: TronAbi = [transfer].into_iter().collect();
+/// assert_eq!(abi.len(), 1);
+/// assert_eq!(abi.items().next().unwrap().name(), Some("transfer"));
+/// ```
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TronAbi {
+    /// The ABI entries in node-provided order.
+    pub entries: Vec<TronAbiEntry>,
+}
+
+impl TronAbi {
+    /// Creates an empty TRON ABI.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tronz_abi::TronAbi;
+    ///
+    /// let abi = TronAbi::new();
+    /// assert!(abi.is_empty());
+    /// ```
+    #[inline]
+    pub const fn new() -> Self {
+        Self { entries: Vec::new() }
+    }
+
+    /// Returns the number of entries in the ABI.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Returns `true` if the ABI contains no entries.
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Returns an iterator over the ABI entries.
+    #[inline]
+    pub fn items(&self) -> slice::Iter<'_, TronAbiEntry> {
+        self.entries.iter()
+    }
+
+    /// Returns a mutable iterator over the ABI entries.
+    #[inline]
+    pub fn items_mut(&mut self) -> slice::IterMut<'_, TronAbiEntry> {
+        self.entries.iter_mut()
+    }
+
+    /// Returns an iterator that takes ownership of the ABI entries.
+    #[inline]
+    pub fn into_items(self) -> vec::IntoIter<TronAbiEntry> {
+        self.entries.into_iter()
+    }
+}
+
+impl FromIterator<TronAbiEntry> for TronAbi {
+    #[inline]
+    fn from_iter<T: IntoIterator<Item = TronAbiEntry>>(iter: T) -> Self {
+        Self { entries: iter.into_iter().collect() }
+    }
+}
+
+impl IntoIterator for TronAbi {
+    type Item = TronAbiEntry;
+    type IntoIter = vec::IntoIter<TronAbiEntry>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.into_items()
+    }
+}
+
+impl<'a> IntoIterator for &'a TronAbi {
+    type Item = &'a TronAbiEntry;
+    type IntoIter = slice::Iter<'a, TronAbiEntry>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.items()
+    }
+}
+
+impl<'a> IntoIterator for &'a mut TronAbi {
+    type Item = &'a mut TronAbiEntry;
+    type IntoIter = slice::IterMut<'a, TronAbiEntry>;
+
+    #[inline]
+    fn into_iter(self) -> Self::IntoIter {
+        self.items_mut()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{TronAbiEntryType, TronAbiStateMutability};
+
+    #[test]
+    fn collection_helpers_preserve_order() {
+        let abi: TronAbi = [
+            TronAbiEntry { entry_type: TronAbiEntryType::Constructor, ..Default::default() },
+            TronAbiEntry { entry_type: TronAbiEntryType::Function, ..Default::default() },
+        ]
+        .into_iter()
+        .collect();
+
+        assert_eq!(abi.len(), 2);
+        assert!(!abi.is_empty());
+        assert_eq!(abi.items().nth(1).unwrap().entry_type, TronAbiEntryType::Function);
+    }
+
+    #[test]
+    fn unknown_numeric_values_round_trip() {
+        assert_eq!(TronAbiEntryType::from_i32(99).as_i32(), 99);
+        assert_eq!(TronAbiStateMutability::from_i32(98).as_i32(), 98);
+    }
+}

--- a/crates/abi/src/alloy.rs
+++ b/crates/abi/src/alloy.rs
@@ -238,6 +238,10 @@ impl TronAbi {
     /// events, and errors by name. Legacy `constant` and `payable` flags are
     /// used only when `state_mutability` is `Unknown(0)`.
     ///
+    /// Each entry is normalized to the fields supported by its Solidity JSON
+    /// ABI item kind. Fields with no meaning for that kind, such as outputs on
+    /// an event or `anonymous` on a function, are ignored.
+    ///
     /// # Errors
     ///
     /// Returns an error for invalid identifiers or types, bare `tuple` types,

--- a/crates/abi/src/alloy.rs
+++ b/crates/abi/src/alloy.rs
@@ -1,0 +1,486 @@
+use alloy_json_abi::{
+    Constructor, Error as JsonAbiError, Event, EventParam, Fallback, Function, JsonAbi, Param,
+    Receive, StateMutability,
+};
+
+use crate::{
+    TronAbi, TronAbiConversionError, TronAbiEntry, TronAbiEntryType, TronAbiParam,
+    TronAbiStateMutability,
+};
+
+fn validate_name(name: &str, allow_empty: bool) -> Result<(), TronAbiConversionError> {
+    if (allow_empty && name.is_empty()) || alloy_json_abi::parser::is_valid_identifier(name) {
+        Ok(())
+    } else {
+        Err(TronAbiConversionError::InvalidName(name.into()))
+    }
+}
+
+fn param_from_json(param: &Param) -> Result<TronAbiParam, TronAbiConversionError> {
+    validate_name(&param.name, true)?;
+    if param.ty.starts_with("tuple") && param.components.is_empty() {
+        return Err(TronAbiConversionError::IncompleteTuple(param.name.clone()));
+    }
+
+    let ty = param.selector_type().into_owned();
+    if ty.is_empty() {
+        return Err(TronAbiConversionError::InvalidType(param.ty.clone()));
+    }
+
+    Ok(TronAbiParam { indexed: false, name: param.name.clone(), ty })
+}
+
+fn event_param_from_json(param: &EventParam) -> Result<TronAbiParam, TronAbiConversionError> {
+    validate_name(&param.name, true)?;
+    if param.ty.starts_with("tuple") && param.components.is_empty() {
+        return Err(TronAbiConversionError::IncompleteTuple(param.name.clone()));
+    }
+
+    let ty = param.selector_type().into_owned();
+    if ty.is_empty() {
+        return Err(TronAbiConversionError::InvalidType(param.ty.clone()));
+    }
+
+    Ok(TronAbiParam { indexed: param.indexed, name: param.name.clone(), ty })
+}
+
+fn param_to_json(param: &TronAbiParam) -> Result<Param, TronAbiConversionError> {
+    validate_name(&param.name, true)?;
+    if param
+        .ty
+        .strip_prefix("tuple")
+        .is_some_and(|suffix| suffix.is_empty() || suffix.starts_with('['))
+    {
+        return Err(TronAbiConversionError::IncompleteTuple(param.name.clone()));
+    }
+
+    let declaration = if param.name.is_empty() {
+        param.ty.clone()
+    } else {
+        format!("{} {}", param.ty, param.name)
+    };
+    Param::parse(&declaration).map_err(|_| TronAbiConversionError::InvalidType(param.ty.clone()))
+}
+
+fn event_param_to_json(param: &TronAbiParam) -> Result<EventParam, TronAbiConversionError> {
+    let param_json = param_to_json(param)?;
+    Ok(EventParam {
+        ty: param_json.ty,
+        name: param_json.name,
+        indexed: param.indexed,
+        components: param_json.components,
+        internal_type: param_json.internal_type,
+    })
+}
+
+fn state_from_json(value: StateMutability) -> TronAbiStateMutability {
+    match value {
+        StateMutability::Pure => TronAbiStateMutability::Pure,
+        StateMutability::View => TronAbiStateMutability::View,
+        StateMutability::NonPayable => TronAbiStateMutability::NonPayable,
+        StateMutability::Payable => TronAbiStateMutability::Payable,
+    }
+}
+
+fn state_to_json(
+    value: TronAbiStateMutability,
+    constant: bool,
+    payable: bool,
+    receive: bool,
+) -> Result<StateMutability, TronAbiConversionError> {
+    match value {
+        TronAbiStateMutability::Unknown(0) if constant && (receive || payable) => {
+            Err(TronAbiConversionError::ConflictingMutability)
+        }
+        TronAbiStateMutability::Unknown(0) if receive || payable => Ok(StateMutability::Payable),
+        TronAbiStateMutability::Unknown(0) if constant => Ok(StateMutability::View),
+        TronAbiStateMutability::Unknown(0) => Ok(StateMutability::NonPayable),
+        TronAbiStateMutability::Unknown(other) => {
+            Err(TronAbiConversionError::InvalidMutability(other))
+        }
+        TronAbiStateMutability::Pure => Ok(StateMutability::Pure),
+        TronAbiStateMutability::View => Ok(StateMutability::View),
+        TronAbiStateMutability::NonPayable => Ok(StateMutability::NonPayable),
+        TronAbiStateMutability::Payable => Ok(StateMutability::Payable),
+    }
+}
+
+fn entry_from_json(
+    entry_type: TronAbiEntryType,
+    name: String,
+    inputs: Vec<TronAbiParam>,
+    outputs: Vec<TronAbiParam>,
+    state_mutability: TronAbiStateMutability,
+    anonymous: bool,
+) -> TronAbiEntry {
+    let constant =
+        matches!(state_mutability, TronAbiStateMutability::Pure | TronAbiStateMutability::View);
+    let payable = state_mutability == TronAbiStateMutability::Payable;
+    TronAbiEntry {
+        entry_type,
+        name,
+        inputs,
+        outputs,
+        anonymous,
+        constant,
+        payable,
+        state_mutability,
+    }
+}
+
+impl TronAbi {
+    /// Converts an Alloy JSON ABI into TRON's metadata model.
+    ///
+    /// Tuple component types are flattened to their canonical selector form
+    /// because TRON metadata has no `components` or `internalType` fields. This
+    /// preserves component types but discards component names and internal
+    /// Solidity types. Item order follows Alloy's grouped iteration order, not
+    /// the original JSON array order.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if an item contains an invalid identifier or a tuple
+    /// does not include the component types needed to form its selector type.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tronz_abi::{JsonAbi, TronAbi};
+    ///
+    /// let json_abi = JsonAbi::parse([
+    ///     "function balanceOf(address owner)(uint256 balance)",
+    ///     "event Transfer(address indexed from, address indexed to, uint256 value)",
+    /// ])?;
+    /// let tron_abi = TronAbi::try_from_json_abi(&json_abi)?;
+    ///
+    /// assert_eq!(tron_abi.len(), 2);
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn try_from_json_abi(abi: &JsonAbi) -> Result<Self, TronAbiConversionError> {
+        let mut entries = Vec::with_capacity(abi.len());
+
+        if let Some(item) = &abi.constructor {
+            let inputs = item.inputs.iter().map(param_from_json).collect::<Result<_, _>>()?;
+            entries.push(entry_from_json(
+                TronAbiEntryType::Constructor,
+                String::new(),
+                inputs,
+                vec![],
+                state_from_json(item.state_mutability),
+                false,
+            ));
+        }
+        if let Some(item) = &abi.fallback {
+            entries.push(entry_from_json(
+                TronAbiEntryType::Fallback,
+                String::new(),
+                vec![],
+                vec![],
+                state_from_json(item.state_mutability),
+                false,
+            ));
+        }
+        if let Some(item) = &abi.receive {
+            entries.push(entry_from_json(
+                TronAbiEntryType::Receive,
+                String::new(),
+                vec![],
+                vec![],
+                state_from_json(item.state_mutability),
+                false,
+            ));
+        }
+        for item in abi.functions() {
+            validate_name(&item.name, false)?;
+            let inputs = item.inputs.iter().map(param_from_json).collect::<Result<_, _>>()?;
+            let outputs = item.outputs.iter().map(param_from_json).collect::<Result<_, _>>()?;
+            entries.push(entry_from_json(
+                TronAbiEntryType::Function,
+                item.name.clone(),
+                inputs,
+                outputs,
+                state_from_json(item.state_mutability),
+                false,
+            ));
+        }
+        for item in abi.events() {
+            validate_name(&item.name, false)?;
+            let inputs = item.inputs.iter().map(event_param_from_json).collect::<Result<_, _>>()?;
+            entries.push(entry_from_json(
+                TronAbiEntryType::Event,
+                item.name.clone(),
+                inputs,
+                vec![],
+                TronAbiStateMutability::Unknown(0),
+                item.anonymous,
+            ));
+        }
+        for item in abi.errors() {
+            validate_name(&item.name, false)?;
+            let inputs = item.inputs.iter().map(param_from_json).collect::<Result<_, _>>()?;
+            entries.push(entry_from_json(
+                TronAbiEntryType::Error,
+                item.name.clone(),
+                inputs,
+                vec![],
+                TronAbiStateMutability::Unknown(0),
+                false,
+            ));
+        }
+
+        Ok(Self { entries })
+    }
+
+    /// Converts TRON contract metadata into an Alloy JSON ABI.
+    ///
+    /// Entry order is not retained because [`JsonAbi`] groups functions,
+    /// events, and errors by name. Legacy `constant` and `payable` flags are
+    /// used only when `state_mutability` is `Unknown(0)`.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error for invalid identifiers or types, bare `tuple` types,
+    /// unknown entry or mutability values, conflicting legacy mutability flags,
+    /// or duplicate constructor, fallback, and receive entries.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tronz_abi::{
+    ///     JsonAbi, TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiParam, TronAbiStateMutability,
+    /// };
+    ///
+    /// let tron_abi = TronAbi {
+    ///     entries: vec![TronAbiEntry {
+    ///         entry_type: TronAbiEntryType::Function,
+    ///         name: "balanceOf".into(),
+    ///         inputs: vec![TronAbiParam::new("owner", "address")],
+    ///         outputs: vec![TronAbiParam::new("balance", "uint256")],
+    ///         constant: true,
+    ///         state_mutability: TronAbiStateMutability::View,
+    ///         ..Default::default()
+    ///     }],
+    /// };
+    /// let json_abi = JsonAbi::try_from(&tron_abi)?;
+    ///
+    /// assert!(json_abi.function("balanceOf").is_some());
+    /// # Ok::<(), Box<dyn std::error::Error>>(())
+    /// ```
+    #[inline]
+    pub fn try_to_json_abi(&self) -> Result<JsonAbi, TronAbiConversionError> {
+        let mut result = JsonAbi::new();
+
+        for entry in &self.entries {
+            match entry.entry_type {
+                TronAbiEntryType::Constructor => {
+                    if result.constructor.is_some() {
+                        return Err(TronAbiConversionError::DuplicateEntry("constructor"));
+                    }
+                    let inputs =
+                        entry.inputs.iter().map(param_to_json).collect::<Result<_, _>>()?;
+                    result.constructor = Some(Constructor {
+                        inputs,
+                        state_mutability: state_to_json(
+                            entry.state_mutability,
+                            entry.constant,
+                            entry.payable,
+                            false,
+                        )?,
+                    });
+                }
+                TronAbiEntryType::Function => {
+                    validate_name(&entry.name, false)?;
+                    let inputs =
+                        entry.inputs.iter().map(param_to_json).collect::<Result<_, _>>()?;
+                    let outputs =
+                        entry.outputs.iter().map(param_to_json).collect::<Result<_, _>>()?;
+                    let function = Function {
+                        name: entry.name.clone(),
+                        inputs,
+                        outputs,
+                        state_mutability: state_to_json(
+                            entry.state_mutability,
+                            entry.constant,
+                            entry.payable,
+                            false,
+                        )?,
+                    };
+                    result.functions.entry(entry.name.clone()).or_default().push(function);
+                }
+                TronAbiEntryType::Event => {
+                    validate_name(&entry.name, false)?;
+                    let inputs =
+                        entry.inputs.iter().map(event_param_to_json).collect::<Result<_, _>>()?;
+                    let event =
+                        Event { name: entry.name.clone(), inputs, anonymous: entry.anonymous };
+                    result.events.entry(entry.name.clone()).or_default().push(event);
+                }
+                TronAbiEntryType::Fallback => {
+                    if result.fallback.is_some() {
+                        return Err(TronAbiConversionError::DuplicateEntry("fallback"));
+                    }
+                    result.fallback = Some(Fallback {
+                        state_mutability: state_to_json(
+                            entry.state_mutability,
+                            entry.constant,
+                            entry.payable,
+                            false,
+                        )?,
+                    });
+                }
+                TronAbiEntryType::Receive => {
+                    if result.receive.is_some() {
+                        return Err(TronAbiConversionError::DuplicateEntry("receive"));
+                    }
+                    result.receive = Some(Receive {
+                        state_mutability: state_to_json(
+                            entry.state_mutability,
+                            entry.constant,
+                            entry.payable,
+                            true,
+                        )?,
+                    });
+                }
+                TronAbiEntryType::Error => {
+                    validate_name(&entry.name, false)?;
+                    let inputs =
+                        entry.inputs.iter().map(param_to_json).collect::<Result<_, _>>()?;
+                    let error = JsonAbiError { name: entry.name.clone(), inputs };
+                    result.errors.entry(entry.name.clone()).or_default().push(error);
+                }
+                TronAbiEntryType::Unknown(value) => {
+                    return Err(TronAbiConversionError::UnknownEntryType(value));
+                }
+            }
+        }
+
+        Ok(result)
+    }
+}
+
+impl TryFrom<&JsonAbi> for TronAbi {
+    type Error = TronAbiConversionError;
+
+    #[inline]
+    fn try_from(abi: &JsonAbi) -> Result<Self, Self::Error> {
+        Self::try_from_json_abi(abi)
+    }
+}
+
+impl TryFrom<JsonAbi> for TronAbi {
+    type Error = TronAbiConversionError;
+
+    #[inline]
+    fn try_from(abi: JsonAbi) -> Result<Self, Self::Error> {
+        Self::try_from_json_abi(&abi)
+    }
+}
+
+impl TryFrom<&TronAbi> for JsonAbi {
+    type Error = TronAbiConversionError;
+
+    #[inline]
+    fn try_from(abi: &TronAbi) -> Result<Self, Self::Error> {
+        abi.try_to_json_abi()
+    }
+}
+
+impl TryFrom<TronAbi> for JsonAbi {
+    type Error = TronAbiConversionError;
+
+    #[inline]
+    fn try_from(abi: TronAbi) -> Result<Self, Self::Error> {
+        abi.try_to_json_abi()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn standard_json_abi_round_trip() {
+        let abi: JsonAbi = serde_json::from_str(
+            r#"[
+                {"type":"constructor","inputs":[{"name":"supply","type":"uint256"}],"stateMutability":"nonpayable"},
+                {"type":"function","name":"balanceOf","inputs":[{"name":"owner","type":"address"}],"outputs":[{"name":"balance","type":"uint256"}],"stateMutability":"view"},
+                {"type":"event","name":"Transfer","inputs":[{"name":"from","type":"address","indexed":true},{"name":"to","type":"address","indexed":true},{"name":"value","type":"uint256","indexed":false}],"anonymous":false},
+                {"type":"error","name":"InsufficientBalance","inputs":[{"name":"owner","type":"address"},{"name":"balance","type":"uint256"}]},
+                {"type":"fallback","stateMutability":"payable"},
+                {"type":"receive","stateMutability":"payable"}
+            ]"#,
+        )
+        .unwrap();
+
+        let tron = TronAbi::try_from(&abi).unwrap();
+        let decoded = JsonAbi::try_from(&tron).unwrap();
+        assert_eq!(decoded, abi);
+    }
+
+    #[test]
+    fn tuple_selector_type_is_preserved() {
+        let abi: JsonAbi = serde_json::from_str(
+            r#"[{
+                "type":"function",
+                "name":"setPair",
+                "inputs":[{
+                    "name":"pair",
+                    "type":"tuple",
+                    "components":[
+                        {"name":"amount","type":"uint256"},
+                        {"name":"owner","type":"address"}
+                    ]
+                }],
+                "outputs":[],
+                "stateMutability":"nonpayable"
+            }]"#,
+        )
+        .unwrap();
+
+        let tron = TronAbi::try_from_json_abi(&abi).unwrap();
+        assert_eq!(tron.entries[0].inputs[0].ty, "(uint256,address)");
+
+        let decoded = tron.try_to_json_abi().unwrap();
+        let original_type = abi.functions().next().unwrap().inputs[0].selector_type();
+        let decoded_type = decoded.functions().next().unwrap().inputs[0].selector_type();
+        assert_eq!(decoded_type, original_type);
+    }
+
+    #[test]
+    fn bare_tuple_remains_readable_but_json_conversion_fails() {
+        let tron = TronAbi {
+            entries: vec![TronAbiEntry {
+                entry_type: TronAbiEntryType::Function,
+                name: "setPair".into(),
+                inputs: vec![TronAbiParam {
+                    name: "pair".into(),
+                    ty: "tuple".into(),
+                    ..Default::default()
+                }],
+                state_mutability: TronAbiStateMutability::NonPayable,
+                ..Default::default()
+            }],
+        };
+
+        assert_eq!(
+            tron.try_to_json_abi(),
+            Err(TronAbiConversionError::IncompleteTuple("pair".into()))
+        );
+    }
+
+    #[test]
+    fn conflicting_legacy_mutability_is_rejected() {
+        let tron = TronAbi {
+            entries: vec![TronAbiEntry {
+                entry_type: TronAbiEntryType::Function,
+                name: "conflicting".into(),
+                constant: true,
+                payable: true,
+                ..Default::default()
+            }],
+        };
+
+        assert_eq!(tron.try_to_json_abi(), Err(TronAbiConversionError::ConflictingMutability));
+    }
+}

--- a/crates/abi/src/error.rs
+++ b/crates/abi/src/error.rs
@@ -1,0 +1,26 @@
+/// Conversion failures between TRON contract metadata and Alloy's JSON ABI.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum TronAbiConversionError {
+    /// An ABI parameter contains an invalid Solidity type.
+    #[error("invalid ABI type `{0}")]
+    InvalidType(String),
+    /// An ABI item or parameter contains an invalid Solidity identifier.
+    #[error("invalid ABI identifier `{0}")]
+    InvalidName(String),
+    /// A TRON ABI entry type cannot be represented as a JSON ABI item.
+    #[error("unknown TRON ABI entry type {0}")]
+    UnknownEntryType(i32),
+    /// A TRON state-mutability value cannot be represented by Alloy.
+    #[error("invalid TRON ABI state mutability {0}")]
+    InvalidMutability(i32),
+    /// Legacy mutability flags contain both `constant` and `payable`.
+    #[error("TRON ABI entry cannot be both constant and payable")]
+    ConflictingMutability,
+    /// A tuple parameter does not contain enough information to recover its components.
+    #[error("tuple ABI parameter `{0}` does not include component types")]
+    IncompleteTuple(String),
+    /// An ABI contains more than one singleton item such as a constructor.
+    #[error("duplicate ABI {0} entry")]
+    DuplicateEntry(&'static str),
+}

--- a/crates/abi/src/item.rs
+++ b/crates/abi/src/item.rs
@@ -1,0 +1,187 @@
+use crate::TronAbiParam;
+
+/// A TRON ABI entry.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TronAbiEntry {
+    /// The entry category.
+    pub entry_type: TronAbiEntryType,
+    /// The function, event, or error name. Empty for singleton entries.
+    pub name: String,
+    /// The input parameters. May be empty.
+    pub inputs: Vec<TronAbiParam>,
+    /// The output parameters. May be empty.
+    pub outputs: Vec<TronAbiParam>,
+    /// Whether an event omits its signature from topic 0.
+    pub anonymous: bool,
+    /// Legacy flag indicating that a function does not modify state.
+    pub constant: bool,
+    /// Legacy flag indicating that an entry accepts TRX.
+    pub payable: bool,
+    /// The state mutability stored by the node.
+    ///
+    /// When this is [`TronAbiStateMutability::Unknown`], the legacy
+    /// [`constant`](Self::constant) and [`payable`](Self::payable) flags may
+    /// provide the only mutability information.
+    pub state_mutability: TronAbiStateMutability,
+}
+
+impl TronAbiEntry {
+    /// Returns the entry category.
+    #[inline]
+    pub const fn entry_type(&self) -> TronAbiEntryType {
+        self.entry_type
+    }
+
+    /// Returns the entry name, or `None` when the stored name is empty.
+    #[inline]
+    pub fn name(&self) -> Option<&str> {
+        (!self.name.is_empty()).then_some(self.name.as_str())
+    }
+
+    /// Returns the input parameters.
+    #[inline]
+    pub fn inputs(&self) -> &[TronAbiParam] {
+        &self.inputs
+    }
+
+    /// Returns the output parameters.
+    #[inline]
+    pub fn outputs(&self) -> &[TronAbiParam] {
+        &self.outputs
+    }
+}
+
+/// A TRON ABI entry category.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum TronAbiEntryType {
+    /// The protobuf `UnknownEntryType` value, or an unrecognized future value.
+    Unknown(i32),
+    /// A contract constructor.
+    Constructor,
+    /// A callable function.
+    Function,
+    /// An emitted event.
+    Event,
+    /// A fallback function.
+    Fallback,
+    /// A plain-TRX receive function.
+    Receive,
+    /// A Solidity custom error.
+    Error,
+}
+
+impl TronAbiEntryType {
+    /// Converts a protobuf numeric value without discarding unknown variants.
+    #[inline]
+    pub const fn from_i32(value: i32) -> Self {
+        match value {
+            1 => Self::Constructor,
+            2 => Self::Function,
+            3 => Self::Event,
+            4 => Self::Fallback,
+            5 => Self::Receive,
+            6 => Self::Error,
+            other => Self::Unknown(other),
+        }
+    }
+
+    /// Returns the protobuf numeric representation.
+    #[inline]
+    pub const fn as_i32(self) -> i32 {
+        match self {
+            Self::Unknown(value) => value,
+            Self::Constructor => 1,
+            Self::Function => 2,
+            Self::Event => 3,
+            Self::Fallback => 4,
+            Self::Receive => 5,
+            Self::Error => 6,
+        }
+    }
+
+    /// Returns the ABI type string for a known entry category.
+    #[inline]
+    pub const fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::Unknown(_) => None,
+            Self::Constructor => Some("constructor"),
+            Self::Function => Some("function"),
+            Self::Event => Some("event"),
+            Self::Fallback => Some("fallback"),
+            Self::Receive => Some("receive"),
+            Self::Error => Some("error"),
+        }
+    }
+}
+
+impl Default for TronAbiEntryType {
+    #[inline]
+    fn default() -> Self {
+        Self::Unknown(0)
+    }
+}
+
+/// State mutability stored in TRON ABI metadata.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
+pub enum TronAbiStateMutability {
+    /// The protobuf `UnknownMutabilityType` value, or an unrecognized future value.
+    Unknown(i32),
+    /// Pure functions promise not to read from or modify state.
+    Pure,
+    /// View functions promise not to modify state.
+    View,
+    /// Nonpayable functions do not accept TRX.
+    NonPayable,
+    /// Payable functions may accept TRX.
+    Payable,
+}
+
+impl TronAbiStateMutability {
+    /// Converts a protobuf numeric value without discarding unknown variants.
+    #[inline]
+    pub const fn from_i32(value: i32) -> Self {
+        match value {
+            1 => Self::Pure,
+            2 => Self::View,
+            3 => Self::NonPayable,
+            4 => Self::Payable,
+            other => Self::Unknown(other),
+        }
+    }
+
+    /// Returns the protobuf numeric representation.
+    #[inline]
+    pub const fn as_i32(self) -> i32 {
+        match self {
+            Self::Unknown(value) => value,
+            Self::Pure => 1,
+            Self::View => 2,
+            Self::NonPayable => 3,
+            Self::Payable => 4,
+        }
+    }
+
+    /// Returns the Solidity string for a known state-mutability value.
+    #[inline]
+    pub const fn as_str(self) -> Option<&'static str> {
+        match self {
+            Self::Unknown(_) => None,
+            Self::Pure => Some("pure"),
+            Self::View => Some("view"),
+            Self::NonPayable => Some("nonpayable"),
+            Self::Payable => Some("payable"),
+        }
+    }
+}
+
+impl Default for TronAbiStateMutability {
+    #[inline]
+    fn default() -> Self {
+        Self::Unknown(0)
+    }
+}

--- a/crates/abi/src/lib.rs
+++ b/crates/abi/src/lib.rs
@@ -1,0 +1,26 @@
+#![doc = include_str!("../README.md")]
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+mod abi;
+mod error;
+mod item;
+mod param;
+
+#[cfg(feature = "alloy")]
+mod alloy;
+
+pub use abi::TronAbi;
+#[cfg(feature = "alloy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloy")))]
+#[doc(no_inline)]
+pub use alloy_json_abi as json_abi;
+#[cfg(feature = "alloy")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloy")))]
+#[doc(no_inline)]
+pub use alloy_json_abi::JsonAbi;
+pub use error::TronAbiConversionError;
+pub use item::{TronAbiEntry, TronAbiEntryType, TronAbiStateMutability};
+pub use param::TronAbiParam;

--- a/crates/abi/src/param.rs
+++ b/crates/abi/src/param.rs
@@ -1,0 +1,62 @@
+/// A TRON ABI input or output parameter.
+///
+/// TRON nodes store only the name, Solidity type string, and event indexing
+/// flag. Solidity JSON ABI `components` and `internalType` metadata are not
+/// available in this representation.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct TronAbiParam {
+    /// Whether an event parameter is stored in a log topic.
+    pub indexed: bool,
+    /// The parameter name, which may be empty.
+    pub name: String,
+    /// The Solidity type string exactly as stored by the TRON node.
+    pub ty: String,
+}
+
+impl TronAbiParam {
+    /// Creates a non-indexed ABI parameter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use tronz_abi::TronAbiParam;
+    ///
+    /// let owner = TronAbiParam::new("owner", "address");
+    /// assert_eq!(owner.name(), "owner");
+    /// assert_eq!(owner.ty(), "address");
+    /// assert!(!owner.is_indexed());
+    ///
+    /// let indexed_owner = owner.with_indexed(true);
+    /// assert!(indexed_owner.is_indexed());
+    /// ```
+    #[inline]
+    pub fn new(name: impl Into<String>, ty: impl Into<String>) -> Self {
+        Self { indexed: false, name: name.into(), ty: ty.into() }
+    }
+
+    /// Sets whether this parameter is indexed in an event.
+    #[inline]
+    pub const fn with_indexed(mut self, indexed: bool) -> Self {
+        self.indexed = indexed;
+        self
+    }
+
+    /// Returns the parameter name.
+    #[inline]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Returns the Solidity type string stored by the node.
+    #[inline]
+    pub fn ty(&self) -> &str {
+        &self.ty
+    }
+
+    /// Returns whether this parameter is indexed in an event.
+    #[inline]
+    pub const fn is_indexed(&self) -> bool {
+        self.indexed
+    }
+}

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -12,6 +12,7 @@ repository   = { workspace = true }
 [dependencies]
 tronz-primitives = { workspace = true }
 tronz-provider   = { workspace = true, optional = true }
+tronz-abi        = { workspace = true, optional = true, features = ["alloy"] }
 tronz-sol-macro  = { workspace = true }
 alloy-primitives = { workspace = true, optional = true }
 alloy-sol-types  = { workspace = true }
@@ -24,6 +25,7 @@ thiserror        = { workspace = true, optional = true }
 # Provider-bound contract instances: ContractInstance, Trc20Instance, etc.
 provider = [
     "dep:tronz-provider",
+    "dep:tronz-abi",
     "dep:thiserror",
     "dep:alloy-primitives",
     "dep:alloy-dyn-abi",

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -18,8 +18,7 @@ hand-rolling an encoder.
 Load a JSON ABI at runtime and call any function by name:
 
 ```rust,ignore
-use tronz_contract::{Interface, instance::ContractExt};
-use alloy_json_abi::JsonAbi;
+use tronz_contract::{Interface, JsonAbi, instance::ContractExt};
 
 let abi: JsonAbi = serde_json::from_str(ABI_JSON).unwrap();
 let contract = provider.contract(address, abi.into());
@@ -31,6 +30,36 @@ let values = contract.call("balanceOf", &[account.into()]).await?;
 let pending = contract.send("transfer", &[to.into(), amount.into()]).await?;
 let receipt = pending.get_receipt().await?;
 ```
+
+## Deploying with ABI metadata
+
+`DeployBuilder` accepts Alloy's typed `JsonAbi` and converts it to native
+`TronAbi` metadata before sending the protobuf request:
+
+```rust,ignore
+use tronz_contract::{ContractExt as _, JsonAbi};
+
+let abi: JsonAbi = serde_json::from_str(ABI_JSON)?;
+let pending = provider
+    .deploy(bytecode)
+    .abi(abi)
+    .name("MyContract")
+    .send()
+    .await?;
+```
+
+Provider queries return native `TronAbi` so all node metadata remains readable,
+including unknown entry types and incomplete tuples. Convert explicitly when a
+dynamic Alloy interface is needed:
+
+```rust,ignore
+let info = provider.get_contract_info(address).await?;
+let json_abi = info.abi.try_to_json_abi()?;
+let contract = provider.contract(address, Interface::new(json_abi));
+```
+
+Use `.tron_abi(abi)` instead of `.abi(abi)` to deploy already-native metadata
+without an Alloy conversion.
 
 ## Standard token interfaces (static ABI)
 

--- a/crates/contract/src/call.rs
+++ b/crates/contract/src/call.rs
@@ -113,9 +113,9 @@ impl<P: TronProvider> CallBuilder<P> {
             .await
             .map_err(|e| ContractError::Provider(ProviderError::Transport(e.into())))?;
         if result.revert_reason.is_some() {
-            return Err(ContractError::Revert(result.output.into()));
+            return Err(ContractError::Revert(result.output));
         }
-        Ok(result.output.into())
+        Ok(result.output)
     }
 
     /// Execute as a **state-changing call** (`trigger_smart_contract`).

--- a/crates/contract/src/deploy.rs
+++ b/crates/contract/src/deploy.rs
@@ -18,10 +18,11 @@
 //! # async fn run(
 //! #     provider: impl tronz_provider::TronProvider,
 //! #     bytecode: tronz_primitives::Bytes,
-//! #     abi: &[u8],
+//! #     abi: tronz_contract::JsonAbi,
 //! # ) -> tronz_contract::Result<()> {
 //! // One-shot: broadcast + wait + return address
-//! let address = provider.deploy(bytecode.clone()).abi(abi).name("MyToken").deploy().await?;
+//! let address =
+//!     provider.deploy(bytecode.clone()).abi(abi.clone()).name("MyToken").deploy().await?;
 //!
 //! // Or split into broadcast + poll separately:
 //! let pending = provider.deploy(bytecode).abi(abi).send().await?;
@@ -30,6 +31,8 @@
 //! # Ok(()) }
 //! ```
 
+use alloy_json_abi::JsonAbi;
+use tronz_abi::TronAbi;
 use tronz_primitives::{Address, Bytes, Trx};
 use tronz_provider::{
     Error as ProviderError, PendingTransaction, TronProvider,
@@ -44,12 +47,17 @@ use crate::error::{ContractError, Result};
 pub struct DeployBuilder<P> {
     provider: P,
     bytecode: Bytes,
-    abi: Vec<u8>,
+    abi: DeploymentAbi,
     call_value: Trx,
     fee_limit: Option<Trx>,
     consume_user_resource_percent: i64,
     origin_energy_limit: i64,
     name: String,
+}
+
+enum DeploymentAbi {
+    Json(JsonAbi),
+    Tron(TronAbi),
 }
 
 impl<P: TronProvider> DeployBuilder<P> {
@@ -58,7 +66,7 @@ impl<P: TronProvider> DeployBuilder<P> {
         Self {
             provider,
             bytecode: bytecode.into(),
-            abi: Vec::new(),
+            abi: DeploymentAbi::Tron(TronAbi::new()),
             call_value: Trx::ZERO,
             fee_limit: None,
             consume_user_resource_percent: 100,
@@ -67,11 +75,21 @@ impl<P: TronProvider> DeployBuilder<P> {
         }
     }
 
-    /// Attach the contract's JSON ABI (used by TRON nodes to validate the
-    /// deployment and store ABI metadata on-chain).
+    /// Attach the contract's Alloy JSON ABI.
+    ///
+    /// Conversion to TRON's native metadata model happens when the transaction
+    /// is sent. Tuple parameters are stored as canonical selector types because
+    /// TRON metadata cannot retain component names or `internalType` values.
     #[inline]
-    pub fn abi(mut self, abi: impl Into<Vec<u8>>) -> Self {
-        self.abi = abi.into();
+    pub fn abi(mut self, abi: JsonAbi) -> Self {
+        self.abi = DeploymentAbi::Json(abi);
+        self
+    }
+
+    /// Attach native TRON ABI metadata without converting through Alloy.
+    #[inline]
+    pub fn tron_abi(mut self, abi: TronAbi) -> Self {
+        self.abi = DeploymentAbi::Tron(abi);
         self
     }
 
@@ -150,11 +168,16 @@ impl<P: TronProvider> DeployBuilder<P> {
             .ok_or_else(ProviderError::no_signer)
             .map_err(ContractError::Provider)?;
 
+        let abi = match self.abi {
+            DeploymentAbi::Json(abi) => TronAbi::try_from(abi)?,
+            DeploymentAbi::Tron(abi) => abi,
+        };
+
         let mut req = TransactionRequest::default().with_contract(
             ContractType::CreateSmartContract(CreateSmartContract {
                 owner_address: owner,
                 bytecode: self.bytecode,
-                abi: self.abi,
+                abi,
                 call_value: self.call_value,
                 consume_user_resource_percent: self.consume_user_resource_percent,
                 origin_energy_limit: self.origin_energy_limit,

--- a/crates/contract/src/error.rs
+++ b/crates/contract/src/error.rs
@@ -24,6 +24,9 @@ pub enum ContractError {
     /// ABI encoding or decoding failed.
     #[error("ABI error: {0}")]
     Abi(#[from] alloy_dyn_abi::Error),
+    /// TRON ABI metadata conversion failed.
+    #[error(transparent)]
+    AbiMetadata(#[from] tronz_abi::TronAbiConversionError),
     /// The requested function name was not found in the ABI.
     #[error("unknown function: `{0}`")]
     UnknownFunction(String),

--- a/crates/contract/src/instance.rs
+++ b/crates/contract/src/instance.rs
@@ -161,11 +161,12 @@ pub trait ContractExt: TronProvider + Sized {
     /// # Example
     ///
     /// ```no_run
-    /// use tronz_contract::ContractExt as _;
+    /// use tronz_contract::{ContractExt as _, JsonAbi};
     /// # async fn run(provider: impl tronz_provider::TronProvider, bytecode: tronz_primitives::Bytes) -> tronz_contract::Result<()> {
+    /// let abi = JsonAbi::new();
     /// let pending = provider
     ///     .deploy(bytecode)
-    ///     .abi(b"[]")
+    ///     .abi(abi)
     ///     .name("MyToken")
     ///     .send()
     ///     .await?;

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -37,7 +37,14 @@ mod interface;
 #[cfg(feature = "provider")]
 pub use alloy_dyn_abi::DecodedEvent;
 #[cfg(feature = "provider")]
+pub use alloy_json_abi::JsonAbi;
+#[cfg(feature = "provider")]
 pub use interface::Interface;
+#[cfg(feature = "provider")]
+pub use tronz_abi::{
+    TronAbi, TronAbiConversionError, TronAbiEntry, TronAbiEntryType, TronAbiParam,
+    TronAbiStateMutability,
+};
 
 #[cfg(feature = "provider")]
 mod instance;

--- a/crates/contract/src/sol_call.rs
+++ b/crates/contract/src/sol_call.rs
@@ -96,7 +96,7 @@ mod tests {
     }
 
     fn canned(output: Vec<u8>) -> ConstantCallResult {
-        ConstantCallResult { output, energy_used: 0, revert_reason: None }
+        ConstantCallResult { output: output.into(), energy_used: 0, revert_reason: None }
     }
 
     #[tokio::test]

--- a/crates/provider/Cargo.toml
+++ b/crates/provider/Cargo.toml
@@ -12,6 +12,7 @@ build        = "build.rs"
 
 [dependencies]
 tronz-primitives = { workspace = true }
+tronz-abi        = { workspace = true }
 tronz-signer     = { workspace = true }
 
 prost       = { workspace = true }
@@ -19,7 +20,6 @@ prost-types = { workspace = true }
 tonic       = { workspace = true }
 tonic-prost = { workspace = true }
 sha2        = { workspace = true }
-serde_json  = { workspace = true }
 futures     = { workspace = true }
 tokio       = { workspace = true }
 tracing     = { workspace = true }

--- a/crates/provider/README.md
+++ b/crates/provider/README.md
@@ -5,6 +5,9 @@ The workhorse crate of the [tronz](https://github.com/throgxyz/tronz) TRON SDK.
 Owns the public TRON domain model, the gRPC transport, and the high-level
 [`TronProvider`] trait with all of its typed operation builders.
 
+Contract metadata is exposed as [`tronz_abi::TronAbi`] so protobuf information
+is preserved without forcing provider-only users to depend on Alloy ABI types.
+
 ## Usage
 
 ```rust,no_run

--- a/crates/provider/build.rs
+++ b/crates/provider/build.rs
@@ -1,6 +1,16 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_prost_build::configure()
         .build_server(false)
+        // Keep high-volume binary payloads reference-counted across the tonic
+        // decode/encode boundary. Fixed-size identifiers and UTF-8-like fields
+        // remain `Vec<u8>` so they do not retain an entire response frame.
+        .bytes(".protocol.TransactionExtention.constant_result")
+        .bytes(".protocol.TriggerSmartContract.data")
+        .bytes(".protocol.SmartContract.bytecode")
+        .bytes(".protocol.SmartContractDataWrapper.runtimecode")
+        .bytes(".protocol.TransactionInfo.Log.data")
+        .bytes(".protocol.Transaction.raw.data")
+        .bytes(".protocol.Transaction.signature")
         .compile_protos(&["proto/tron/api/api.proto"], &["proto/tron", "proto"])?;
     Ok(())
 }

--- a/crates/provider/src/builders/account.rs
+++ b/crates/provider/src/builders/account.rs
@@ -1,6 +1,6 @@
 //! Account management builders: create and rename accounts.
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use super::resolve_owner;
 use crate::{
@@ -19,7 +19,7 @@ pub struct CreateAccountBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     account_address: Option<Address>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> CreateAccountBuilder<'a, P> {
@@ -40,7 +40,7 @@ impl<'a, P: TronProvider> CreateAccountBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -72,7 +72,7 @@ pub struct UpdateAccountBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     name: Option<String>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateAccountBuilder<'a, P> {
@@ -93,7 +93,7 @@ impl<'a, P: TronProvider> UpdateAccountBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/builders/contract.rs
+++ b/crates/provider/src/builders/contract.rs
@@ -1,6 +1,6 @@
 //! Smart-contract management builders.
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use super::resolve_owner;
 use crate::{
@@ -22,7 +22,7 @@ pub struct SetAccountIdBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     account_id: Option<String>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> SetAccountIdBuilder<'a, P> {
@@ -43,7 +43,7 @@ impl<'a, P: TronProvider> SetAccountIdBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -75,7 +75,7 @@ pub struct ClearContractAbiBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     contract_address: Option<Address>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ClearContractAbiBuilder<'a, P> {
@@ -96,7 +96,7 @@ impl<'a, P: TronProvider> ClearContractAbiBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -130,7 +130,7 @@ pub struct UpdateContractSettingBuilder<'a, P> {
     owner: Option<Address>,
     contract_address: Option<Address>,
     consume_user_resource_percent: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateContractSettingBuilder<'a, P> {
@@ -163,7 +163,7 @@ impl<'a, P: TronProvider> UpdateContractSettingBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -201,7 +201,7 @@ pub struct UpdateContractEnergyLimitBuilder<'a, P> {
     owner: Option<Address>,
     contract_address: Option<Address>,
     origin_energy_limit: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateContractEnergyLimitBuilder<'a, P> {
@@ -234,7 +234,7 @@ impl<'a, P: TronProvider> UpdateContractEnergyLimitBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/builders/transfer.rs
+++ b/crates/provider/src/builders/transfer.rs
@@ -1,6 +1,6 @@
 //! TRX transfer builder.
 
-use tronz_primitives::{Address, Trx};
+use tronz_primitives::{Address, Bytes, Trx};
 
 use super::resolve_owner;
 use crate::{
@@ -15,7 +15,7 @@ pub struct TransferBuilder<'a, P> {
     owner: Option<Address>,
     to: Option<Address>,
     amount: Option<Trx>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> TransferBuilder<'a, P> {
@@ -43,7 +43,7 @@ impl<'a, P: TronProvider> TransferBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/builders/vote.rs
+++ b/crates/provider/src/builders/vote.rs
@@ -1,6 +1,6 @@
 //! SR vote builder.
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use super::resolve_owner;
 use crate::{
@@ -32,7 +32,7 @@ pub struct VoteBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     votes: Vec<SrVote>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> VoteBuilder<'a, P> {
@@ -63,7 +63,7 @@ impl<'a, P: TronProvider> VoteBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/ext/exchange.rs
+++ b/crates/provider/src/ext/exchange.rs
@@ -2,7 +2,7 @@
 //!
 //! Import [`ExchangeApi`] to add exchange methods to any [`TronProvider`].
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use crate::{
     builders::resolve_owner,
@@ -121,7 +121,7 @@ pub struct ExchangeCreateBuilder<'a, P> {
     first_token_balance: Option<i64>,
     second_token_id: Option<String>,
     second_token_balance: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ExchangeCreateBuilder<'a, P> {
@@ -168,7 +168,7 @@ impl<'a, P: TronProvider> ExchangeCreateBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -210,7 +210,7 @@ pub struct ExchangeInjectBuilder<'a, P> {
     exchange_id: Option<i64>,
     token_id: Option<String>,
     quant: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ExchangeInjectBuilder<'a, P> {
@@ -243,7 +243,7 @@ impl<'a, P: TronProvider> ExchangeInjectBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -280,7 +280,7 @@ pub struct ExchangeWithdrawBuilder<'a, P> {
     exchange_id: Option<i64>,
     token_id: Option<String>,
     quant: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ExchangeWithdrawBuilder<'a, P> {
@@ -313,7 +313,7 @@ impl<'a, P: TronProvider> ExchangeWithdrawBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -351,7 +351,7 @@ pub struct ExchangeTradeBuilder<'a, P> {
     token_id: Option<String>,
     quant: Option<i64>,
     expected: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ExchangeTradeBuilder<'a, P> {
@@ -398,7 +398,7 @@ impl<'a, P: TronProvider> ExchangeTradeBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/ext/governance.rs
+++ b/crates/provider/src/ext/governance.rs
@@ -4,7 +4,7 @@
 
 use std::collections::HashMap;
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use crate::{
     builders::resolve_owner,
@@ -109,7 +109,7 @@ pub struct SubmitProposalBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     parameters: HashMap<i64, i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> SubmitProposalBuilder<'a, P> {
@@ -138,7 +138,7 @@ impl<'a, P: TronProvider> SubmitProposalBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -172,7 +172,7 @@ pub struct ApproveProposalBuilder<'a, P> {
     owner: Option<Address>,
     proposal_id: Option<i64>,
     is_add_approval: bool,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ApproveProposalBuilder<'a, P> {
@@ -201,7 +201,7 @@ impl<'a, P: TronProvider> ApproveProposalBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -233,7 +233,7 @@ pub struct CancelProposalBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     proposal_id: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> CancelProposalBuilder<'a, P> {
@@ -254,7 +254,7 @@ impl<'a, P: TronProvider> CancelProposalBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/ext/market.rs
+++ b/crates/provider/src/ext/market.rs
@@ -2,7 +2,7 @@
 //!
 //! Import [`MarketApi`] to add market-order methods to any [`TronProvider`].
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, B256, Bytes};
 
 use crate::{
     builders::resolve_owner,
@@ -42,7 +42,7 @@ pub trait MarketApi: TronProvider + Sized {
     /// Returns `None` if no order with that ID exists.
     fn get_market_order_by_id(
         &self,
-        order_id: &[u8],
+        order_id: B256,
     ) -> impl std::future::Future<Output = Result<Option<MarketOrderInfo>>> + Send;
 
     /// Fetch all market orders placed by `address`.
@@ -78,7 +78,7 @@ pub trait MarketApi: TronProvider + Sized {
 }
 
 impl<P: TronProvider> MarketApi for P {
-    async fn get_market_order_by_id(&self, order_id: &[u8]) -> Result<Option<MarketOrderInfo>> {
+    async fn get_market_order_by_id(&self, order_id: B256) -> Result<Option<MarketOrderInfo>> {
         self.transport().get_market_order_by_id(order_id).await.map_err(|e| Error::from(e.into()))
     }
 
@@ -136,7 +136,7 @@ pub struct MarketSellBuilder<'a, P> {
     sell_token_quantity: Option<i64>,
     buy_token_id: Option<String>,
     buy_token_quantity: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> MarketSellBuilder<'a, P> {
@@ -183,7 +183,7 @@ impl<'a, P: TronProvider> MarketSellBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -221,8 +221,8 @@ impl<'a, P: TronProvider> MarketSellBuilder<'a, P> {
 pub struct MarketCancelBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
-    order_id: Option<Vec<u8>>,
-    memo: Option<Vec<u8>>,
+    order_id: Option<B256>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> MarketCancelBuilder<'a, P> {
@@ -237,13 +237,13 @@ impl<'a, P: TronProvider> MarketCancelBuilder<'a, P> {
     }
 
     /// Set the 32-byte order ID to cancel.
-    pub fn order_id(mut self, id: impl Into<Vec<u8>>) -> Self {
-        self.order_id = Some(id.into());
+    pub fn order_id(mut self, id: B256) -> Self {
+        self.order_id = Some(id);
         self
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -289,7 +289,7 @@ mod tests {
 
     fn order(owner: Address) -> MarketOrderInfo {
         MarketOrderInfo {
-            order_id: vec![0u8; 32],
+            order_id: B256::ZERO,
             owner_address: owner,
             create_time: 0,
             sell_token_id: "_".into(),

--- a/crates/provider/src/ext/trc10.rs
+++ b/crates/provider/src/ext/trc10.rs
@@ -2,7 +2,7 @@
 //!
 //! Import [`Trc10Api`] to add TRC10 methods to any [`TronProvider`].
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use crate::{
     builders::resolve_owner,
@@ -191,7 +191,7 @@ pub struct TransferTrc10Builder<'a, P> {
     to: Option<Address>,
     token_id: Option<String>,
     amount: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> TransferTrc10Builder<'a, P> {
@@ -224,7 +224,7 @@ impl<'a, P: TronProvider> TransferTrc10Builder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -427,7 +427,7 @@ pub struct ParticipateTrc10Builder<'a, P> {
     to: Option<Address>,
     token_id: Option<String>,
     amount: Option<i64>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> ParticipateTrc10Builder<'a, P> {
@@ -460,7 +460,7 @@ impl<'a, P: TronProvider> ParticipateTrc10Builder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -494,7 +494,7 @@ impl<'a, P: TronProvider> ParticipateTrc10Builder<'a, P> {
 pub struct UnfreezeTrc10Builder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UnfreezeTrc10Builder<'a, P> {
@@ -509,7 +509,7 @@ impl<'a, P: TronProvider> UnfreezeTrc10Builder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -541,7 +541,7 @@ pub struct UpdateTrc10Builder<'a, P> {
     url: Option<String>,
     new_limit: i64,
     new_public_limit: i64,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateTrc10Builder<'a, P> {
@@ -588,7 +588,7 @@ impl<'a, P: TronProvider> UpdateTrc10Builder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/ext/witness.rs
+++ b/crates/provider/src/ext/witness.rs
@@ -2,7 +2,7 @@
 //!
 //! Import [`WitnessApi`] to add SR management methods to any [`TronProvider`].
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, Bytes};
 
 use crate::{
     builders::resolve_owner,
@@ -103,7 +103,7 @@ pub struct BecomeWitnessBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     url: Option<String>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> BecomeWitnessBuilder<'a, P> {
@@ -124,7 +124,7 @@ impl<'a, P: TronProvider> BecomeWitnessBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -155,7 +155,7 @@ pub struct UpdateWitnessBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     update_url: Option<String>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateWitnessBuilder<'a, P> {
@@ -176,7 +176,7 @@ impl<'a, P: TronProvider> UpdateWitnessBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -207,7 +207,7 @@ pub struct UpdateBrokerageBuilder<'a, P> {
     provider: &'a P,
     owner: Option<Address>,
     brokerage: Option<i32>,
-    memo: Option<Vec<u8>>,
+    memo: Option<Bytes>,
 }
 
 impl<'a, P: TronProvider> UpdateBrokerageBuilder<'a, P> {
@@ -231,7 +231,7 @@ impl<'a, P: TronProvider> UpdateBrokerageBuilder<'a, P> {
     }
 
     /// Attach a memo.
-    pub fn memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }

--- a/crates/provider/src/fillers/mod.rs
+++ b/crates/provider/src/fillers/mod.rs
@@ -5,10 +5,11 @@
 
 use core::future::Future;
 use std::{
-    sync::{Arc, Mutex},
+    sync::Arc,
     time::{Duration, Instant},
 };
 
+use tokio::sync::Mutex;
 use tronz_primitives::{Address, B256, RecoverableSignature, Trx};
 use tronz_signer::{SignerError, TronSigner};
 
@@ -165,22 +166,24 @@ impl TxFiller for TaposFiller {
                 return Ok(tx);
             }
 
-            // Return the cached block if it is still fresh.  The lock is held
-            // only while reading the Option — never across an await point.
-            let cached_block = cached
-                .lock()
-                .unwrap()
-                .as_ref()
-                .and_then(|(b, t)| (t.elapsed() < block_ttl).then(|| b.clone()));
-
-            let block = match cached_block {
-                Some(b) => b,
-                None => {
-                    let b = provider.get_now_block().await?;
-                    *cached.lock().unwrap() = Some((b.clone(), Instant::now()));
-                    b
+            // Keep the async mutex through a cache miss so concurrent callers
+            // coalesce into one get_now_block request instead of stampeding the
+            // node when the TTL expires.
+            let mut cache = cached.lock().await;
+            let block = if let Some((block, fetched_at)) = cache.as_ref() {
+                if fetched_at.elapsed() < block_ttl {
+                    block.clone()
+                } else {
+                    let block = provider.get_now_block().await?;
+                    *cache = Some((block.clone(), Instant::now()));
+                    block
                 }
+            } else {
+                let block = provider.get_now_block().await?;
+                *cache = Some((block.clone(), Instant::now()));
+                block
             };
+            drop(cache);
 
             let mut tx = tx;
             tx.ref_block_bytes = Some(block.ref_block_bytes());
@@ -426,6 +429,24 @@ mod tests {
         filler.fill(TransactionRequest::default(), &provider).await.unwrap();
         // Clone shares the Arc — no second push_ok needed.
         clone.fill(TransactionRequest::default(), &provider).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn tapos_filler_coalesces_concurrent_cache_misses() {
+        let provider = mock_provider();
+        // Only one response is available. A second concurrent node request
+        // would make MockTransport panic.
+        provider.transport().push_ok("get_now_block", block(7, 4_000_000));
+
+        let filler = TaposFiller::new();
+        let clone = filler.clone();
+        let (first, second) = tokio::join!(
+            filler.fill(TransactionRequest::default(), &provider),
+            clone.fill(TransactionRequest::default(), &provider),
+        );
+
+        assert_eq!(first.unwrap().timestamp, Some(4_000_000));
+        assert_eq!(second.unwrap().timestamp, Some(4_000_000));
     }
 
     // ── FeeLimitFiller ───────────────────────────────────────────────────────

--- a/crates/provider/src/provider/builder.rs
+++ b/crates/provider/src/provider/builder.rs
@@ -98,14 +98,16 @@ impl<F: TxFiller> ProviderBuilder<F> {
         self
     }
 
-    /// Add both the TAPOS filler and a 20 TRX default fee-limit filler in one
-    /// call — the most common setup for a read/write provider.
+    /// Add the recommended filler chain.
     ///
-    /// Equivalent to `.with_tapos().with_fee_limit(Trx::from_sun(20_000_000).unwrap())`.
-    pub fn with_recommended_fillers(
-        self,
-    ) -> ProviderBuilder<JoinFill<JoinFill<F, TaposFiller>, FeeLimitFiller>> {
-        self.with_tapos().with_fee_limit(Trx::from_sun_unchecked(20_000_000))
+    /// This currently installs a 20 TRX default fee limit. All supported
+    /// transaction builders ask the node to construct the transaction, so TAPOS
+    /// is already filled by the node. Use [`with_tapos`] explicitly only when
+    /// overriding TAPOS for a locally referenced block.
+    ///
+    /// [`with_tapos`]: Self::with_tapos
+    pub fn with_recommended_fillers(self) -> ProviderBuilder<JoinFill<F, FeeLimitFiller>> {
+        self.with_fee_limit(Trx::from_sun_unchecked(20_000_000))
     }
 
     /// Add the TAPOS filler (required before broadcasting client-built txs).
@@ -247,7 +249,7 @@ impl<T: TronTransport, F: TxFiller + HasSigner + 'static> TronProvider for Fille
     // ── send_transaction ─────────────────────────────────────────────────────
 
     async fn send_transaction(&self, req: TransactionRequest) -> Result<PendingTransaction<Self>> {
-        // Build (fill TAPOS / fee-limit + node round-trip), then sign & broadcast.
+        // Build (run configured fillers + node round-trip), then sign & broadcast.
         let raw = self.build_transaction(req).await?;
 
         let sig = self
@@ -361,14 +363,46 @@ impl<T: TronTransport, F: TxFiller + HasSigner + 'static> FilledProvider<T, F> {
         };
         let mut raw = raw_result.map_err(|e| Error::from(e.into()))?;
 
-        // ── 3. Apply fee_limit / memo / permission_id ────────────────────────
-        raw.apply_request_fields(
-            req.fee_limit.map(|t| t.as_sun()),
-            req.memo.as_deref(),
-            req.permission_id,
-        )
-        .map_err(Error::Transport)?;
+        // ── 3. Apply request-level overrides ────────────────────────────────
+        raw.apply_request_fields(&req).map_err(Error::Transport)?;
 
         Ok(raw)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tronz_primitives::{Address, Bytes};
+
+    use super::*;
+    use crate::{
+        transport::mock::MockTransport,
+        types::{ContractType, TriggerSmartContract},
+    };
+
+    #[tokio::test]
+    async fn recommended_fillers_do_not_fetch_tapos() {
+        // No get_now_block response is queued. The mock would panic if the
+        // recommended chain still contained TaposFiller.
+        let provider = RootProvider::new(MockTransport::new());
+        let builder = ProviderBuilder::new().with_recommended_fillers();
+        let address = Address::from_evm_bytes([1; 20]);
+        let request = TransactionRequest {
+            contract: Some(ContractType::TriggerSmartContract(TriggerSmartContract {
+                owner_address: address,
+                contract_address: address,
+                call_value: Trx::ZERO,
+                data: Bytes::new(),
+                call_token_value: Trx::ZERO,
+                token_id: 0,
+            })),
+            ..Default::default()
+        };
+
+        let mut filled = builder.filler.fill(request, &provider).await.unwrap();
+        builder.filler.fill_sync(&mut filled);
+
+        assert_eq!(filled.fee_limit, Some(Trx::from_sun_unchecked(20_000_000)));
+        assert!(filled.ref_block_bytes.is_none());
     }
 }

--- a/crates/provider/src/transport/grpc/abi.rs
+++ b/crates/provider/src/transport/grpc/abi.rs
@@ -1,0 +1,84 @@
+//! Exact conversions between TRON ABI domain types and generated protobuf types.
+
+use tronz_abi::{TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiParam, TronAbiStateMutability};
+
+use crate::proto;
+
+type ProtoAbi = proto::smart_contract::Abi;
+type ProtoAbiEntry = proto::smart_contract::abi::Entry;
+type ProtoAbiParam = proto::smart_contract::abi::entry::Param;
+
+pub(super) fn from_proto(abi: ProtoAbi) -> TronAbi {
+    TronAbi {
+        entries: abi
+            .entrys
+            .into_iter()
+            .map(|entry| TronAbiEntry {
+                entry_type: TronAbiEntryType::from_i32(entry.r#type),
+                name: entry.name,
+                inputs: entry.inputs.into_iter().map(param_from_proto).collect(),
+                outputs: entry.outputs.into_iter().map(param_from_proto).collect(),
+                anonymous: entry.anonymous,
+                constant: entry.constant,
+                payable: entry.payable,
+                state_mutability: TronAbiStateMutability::from_i32(entry.state_mutability),
+            })
+            .collect(),
+    }
+}
+
+pub(super) fn to_proto(abi: TronAbi) -> ProtoAbi {
+    ProtoAbi {
+        entrys: abi
+            .entries
+            .into_iter()
+            .map(|entry| ProtoAbiEntry {
+                anonymous: entry.anonymous,
+                constant: entry.constant,
+                name: entry.name,
+                inputs: entry.inputs.into_iter().map(param_to_proto).collect(),
+                outputs: entry.outputs.into_iter().map(param_to_proto).collect(),
+                r#type: entry.entry_type.as_i32(),
+                payable: entry.payable,
+                state_mutability: entry.state_mutability.as_i32(),
+            })
+            .collect(),
+    }
+}
+
+fn param_from_proto(param: ProtoAbiParam) -> TronAbiParam {
+    TronAbiParam { indexed: param.indexed, name: param.name, ty: param.r#type }
+}
+
+fn param_to_proto(param: TronAbiParam) -> ProtoAbiParam {
+    ProtoAbiParam { indexed: param.indexed, name: param.name, r#type: param.ty }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn protobuf_round_trip_preserves_unknown_values_and_bare_tuple() {
+        let proto = ProtoAbi {
+            entrys: vec![ProtoAbiEntry {
+                name: "setPair".into(),
+                inputs: vec![ProtoAbiParam {
+                    indexed: false,
+                    name: "pair".into(),
+                    r#type: "tuple".into(),
+                }],
+                r#type: 99,
+                state_mutability: 98,
+                constant: true,
+                ..Default::default()
+            }],
+        };
+
+        let domain = from_proto(proto.clone());
+        assert_eq!(domain.entries[0].entry_type, TronAbiEntryType::Unknown(99));
+        assert_eq!(domain.entries[0].state_mutability, TronAbiStateMutability::Unknown(98));
+        assert_eq!(domain.entries[0].inputs[0].ty, "tuple");
+        assert_eq!(to_proto(domain), proto);
+    }
+}

--- a/crates/provider/src/transport/grpc/codec.rs
+++ b/crates/provider/src/transport/grpc/codec.rs
@@ -10,7 +10,7 @@ use crate::{
     proto,
     types::{
         AccountInfo, AccountPermissionUpdateContract, AccountPermissions, AccountResource,
-        AssetInfo, AssetIssueContract, BlockInfo, ClearContractAbiContract, ConstantCallResult,
+        AssetInfo, AssetIssueContract, ClearContractAbiContract, ConstantCallResult,
         ContractResult, CreateAccountContract, CreateSmartContract, CreateWitnessContract,
         DelegatedResource, DelegatedResourceIndex, ExchangeCreateContract, ExchangeInfo,
         ExchangeInjectContract, ExchangeTransactionContract, ExchangeWithdrawContract, FreezeV2,
@@ -53,8 +53,8 @@ fn opt_addr(bytes: Vec<u8>) -> Option<Address> {
 /// exactly 32 bytes, and emits a `warn!`.
 ///
 /// This is acceptable for log topics (a wrong-length topic simply won't match
-/// any filter) but **not** for block hashes — see [`block_from_extention`]
-/// which validates the length explicitly.
+/// any filter). Block-summary conversion validates block hash lengths instead
+/// of using this fallback.
 fn b256(bytes: Vec<u8>) -> B256 {
     if bytes.len() == 32 {
         let mut arr = [0u8; 32];
@@ -64,31 +64,6 @@ fn b256(bytes: Vec<u8>) -> B256 {
         warn!(len = bytes.len(), "unexpected b256 byte length from node, substituting B256::ZERO");
         B256::ZERO
     }
-}
-
-// ── Block ─────────────────────────────────────────────────────────────────────
-
-pub(super) fn block_from_extention(
-    ext: proto::BlockExtention,
-) -> Result<BlockInfo, TransportErrorKind> {
-    let header = ext
-        .block_header
-        .ok_or_else(|| TransportErrorKind::Malformed("missing block_header".into()))?;
-    let raw = header
-        .raw_data
-        .ok_or_else(|| TransportErrorKind::Malformed("missing block_header.raw_data".into()))?;
-
-    // Block id must be exactly 32 bytes — a wrong length here would silently
-    // corrupt TAPOS (ref_block_hash becomes zero → node rejects the tx).
-    let blockid = ext.blockid;
-    if blockid.len() != 32 {
-        return Err(TransportErrorKind::Malformed(format!(
-            "blockid must be 32 bytes, got {}",
-            blockid.len()
-        )));
-    }
-
-    Ok(BlockInfo { number: raw.number, hash: b256(blockid), timestamp: raw.timestamp })
 }
 
 // ── Account ───────────────────────────────────────────────────────────────────
@@ -314,7 +289,7 @@ pub(super) fn trigger_smart_contract_to_proto(
         owner_address: addr_bytes(p.owner_address),
         contract_address: addr_bytes(p.contract_address),
         call_value: p.call_value.as_sun(),
-        data: p.data.to_vec(),
+        data: p.data.into(),
         call_token_value: p.call_token_value.as_sun(),
         token_id: p.token_id,
     }
@@ -323,7 +298,7 @@ pub(super) fn trigger_smart_contract_to_proto(
 pub(super) fn constant_result_from_extention(
     ext: proto::TransactionExtention,
 ) -> Result<ConstantCallResult, TransportErrorKind> {
-    let output = ext.constant_result.into_iter().next().unwrap_or_default();
+    let output: Bytes = ext.constant_result.into_iter().next().unwrap_or_default().into();
 
     let revert_reason = if let Some(ref r) = ext.result {
         if !r.result {
@@ -344,78 +319,11 @@ pub(super) fn constant_result_from_extention(
     Ok(ConstantCallResult { output, energy_used: ext.energy_used, revert_reason })
 }
 
-/// Convert a proto `SmartContract.ABI` to a JSON ABI byte array compatible
-/// with alloy's `JsonAbi` / EIP-712 tooling.
-fn abi_to_json(abi: proto::smart_contract::Abi) -> Vec<u8> {
-    fn state_mutability(v: i32) -> &'static str {
-        match v {
-            1 => "pure",
-            2 => "view",
-            4 => "payable",
-            _ => "nonpayable",
-        }
-    }
-
-    fn param_to_json(p: &proto::smart_contract::abi::entry::Param) -> serde_json::Value {
-        let mut obj = serde_json::json!({ "name": p.name, "type": p.r#type });
-        if p.indexed {
-            obj["indexed"] = serde_json::json!(true);
-        }
-        obj
-    }
-
-    let entries: Vec<serde_json::Value> = abi
-        .entrys
-        .into_iter()
-        .filter_map(|e| {
-            // EntryType: 0=Unknown, 1=Constructor, 2=Function, 3=Event,
-            //            4=Fallback, 5=Receive, 6=Error
-            let entry = match e.r#type {
-                1 => serde_json::json!({
-                    "type": "constructor",
-                    "inputs": e.inputs.iter().map(param_to_json).collect::<Vec<_>>(),
-                    "stateMutability": state_mutability(e.state_mutability),
-                }),
-                2 => serde_json::json!({
-                    "type": "function",
-                    "name": e.name,
-                    "inputs": e.inputs.iter().map(param_to_json).collect::<Vec<_>>(),
-                    "outputs": e.outputs.iter().map(param_to_json).collect::<Vec<_>>(),
-                    "stateMutability": state_mutability(e.state_mutability),
-                }),
-                3 => serde_json::json!({
-                    "type": "event",
-                    "name": e.name,
-                    "inputs": e.inputs.iter().map(param_to_json).collect::<Vec<_>>(),
-                    "anonymous": e.anonymous,
-                }),
-                4 => serde_json::json!({
-                    "type": "fallback",
-                    "stateMutability": state_mutability(e.state_mutability),
-                }),
-                5 => serde_json::json!({
-                    "type": "receive",
-                    "stateMutability": "payable",
-                }),
-                6 => serde_json::json!({
-                    "type": "error",
-                    "name": e.name,
-                    "inputs": e.inputs.iter().map(param_to_json).collect::<Vec<_>>(),
-                }),
-                _ => return None, // skip UnknownEntryType
-            };
-            Some(entry)
-        })
-        .collect();
-
-    serde_json::to_vec(&entries).unwrap_or_default()
-}
-
 pub(super) fn smart_contract_from_proto(c: proto::SmartContract) -> SmartContractInfo {
     SmartContractInfo {
         address: opt_addr(c.contract_address),
         origin_address: opt_addr(c.origin_address),
-        abi: c.abi.map(abi_to_json).unwrap_or_default(),
+        abi: c.abi.map(super::abi::from_proto).unwrap_or_default(),
         bytecode: Bytes::from(c.bytecode),
         runtime_bytecode: None,
         name: c.name,
@@ -558,8 +466,8 @@ pub(super) fn create_smart_contract_to_proto(p: CreateSmartContract) -> proto::C
         new_contract: Some(proto::SmartContract {
             origin_address: addr_bytes(p.owner_address),
             contract_address: vec![],
-            abi: None,
-            bytecode: p.bytecode.to_vec(),
+            abi: Some(super::abi::to_proto(p.abi)),
+            bytecode: p.bytecode.into(),
             call_value: p.call_value.as_sun(),
             consume_user_resource_percent: p.consume_user_resource_percent,
             name: p.name,
@@ -801,30 +709,6 @@ pub(super) fn update_energy_limit_to_proto(
     }
 }
 
-// ── Block (plain, non-extention) ───────────────────────────────────────────────
-
-/// Convert a plain `Block` proto (returned by `GetBlockById`, etc.) into `BlockInfo`.
-pub(super) fn block_from_plain(block: proto::Block) -> Result<BlockInfo, TransportErrorKind> {
-    let header = block
-        .block_header
-        .ok_or_else(|| TransportErrorKind::Malformed("missing block_header".into()))?;
-    let raw = header
-        .raw_data
-        .ok_or_else(|| TransportErrorKind::Malformed("missing block_header.raw_data".into()))?;
-
-    // For plain Block the block id isn't included — derive it from the header bytes.
-    use prost::Message as _;
-    use sha2::{Digest, Sha256};
-    let header_bytes = raw.encode_to_vec();
-    let hash_bytes: [u8; 32] = Sha256::digest(&header_bytes).into();
-    // Embed the block number in the first 8 bytes (TRON convention).
-    let mut block_id = hash_bytes;
-    let num_be = raw.number.to_be_bytes();
-    block_id[0..8].copy_from_slice(&num_be);
-
-    Ok(BlockInfo { number: raw.number, hash: B256::from(block_id), timestamp: raw.timestamp })
-}
-
 // ── Raw transaction from plain Transaction proto ───────────────────────────────
 
 /// Convert a plain `Transaction` proto into a `RawTransaction`.
@@ -922,7 +806,7 @@ pub(super) fn market_cancel_order_to_proto(
 ) -> proto::MarketCancelOrderContract {
     proto::MarketCancelOrderContract {
         owner_address: addr_bytes(p.owner_address),
-        order_id: p.order_id,
+        order_id: p.order_id.as_slice().to_vec(),
     }
 }
 
@@ -934,8 +818,12 @@ pub(super) fn market_order_from_proto(
         2 => MarketOrderState::Canceled,
         _ => MarketOrderState::Active,
     };
+    let order_id: [u8; 32] = o
+        .order_id
+        .try_into()
+        .map_err(|_| TransportErrorKind::Malformed("market order id must be 32 bytes".into()))?;
     Ok(MarketOrderInfo {
-        order_id: o.order_id,
+        order_id: B256::from(order_id),
         owner_address: addr(o.owner_address)?,
         create_time: o.create_time,
         sell_token_id: String::from_utf8_lossy(&o.sell_token_id).into_owned(),
@@ -981,4 +869,40 @@ pub(super) fn sign_weight_from_proto(
     let result = w.result.as_ref().map(|r| r.message.clone()).unwrap_or_default();
 
     Ok(SignWeight { approved_list, current_weight: w.current_weight, required_weight, result })
+}
+
+#[cfg(test)]
+mod tests {
+    use tronz_abi::{TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiStateMutability};
+    use tronz_primitives::{Address, Bytes, Trx};
+
+    use super::*;
+
+    #[test]
+    fn deploy_contract_includes_typed_abi() {
+        let abi = TronAbi {
+            entries: vec![TronAbiEntry {
+                entry_type: TronAbiEntryType::Function,
+                name: "totalSupply".into(),
+                constant: true,
+                state_mutability: TronAbiStateMutability::View,
+                ..Default::default()
+            }],
+        };
+        let owner = Address::from_slice(&[0x41; 21]).unwrap();
+        let request = CreateSmartContract {
+            owner_address: owner,
+            bytecode: Bytes::from_static(&[0x60, 0x00]),
+            abi,
+            call_value: Trx::ZERO,
+            consume_user_resource_percent: 100,
+            origin_energy_limit: 10_000_000,
+            name: "Token".into(),
+        };
+
+        let proto = create_smart_contract_to_proto(request);
+        let stored = proto.new_contract.unwrap().abi.unwrap();
+        assert_eq!(stored.entrys.len(), 1);
+        assert_eq!(stored.entrys[0].name, "totalSupply");
+    }
 }

--- a/crates/provider/src/transport/grpc/light_block.rs
+++ b/crates/provider/src/transport/grpc/light_block.rs
@@ -1,0 +1,122 @@
+//! Wire-compatible protobuf views used by block-summary RPCs.
+//!
+//! TRON's block endpoints return every transaction in the block, while the
+//! public provider methods in this crate return only [`BlockInfo`]. Omitting
+//! protobuf field `1` from these views lets prost skip the transaction payload
+//! without allocating or decoding nested messages.
+
+use prost::Message;
+use tronz_primitives::{B256, Bytes};
+
+use crate::{error::TransportErrorKind, types::BlockInfo};
+
+#[derive(Clone, PartialEq, Message)]
+pub(super) struct BlockSummaryProto {
+    #[prost(message, optional, tag = "2")]
+    block_header: Option<BlockHeaderSummaryProto>,
+    #[prost(bytes = "bytes", tag = "3")]
+    block_id: prost::bytes::Bytes,
+}
+
+#[derive(Clone, PartialEq, Message)]
+struct BlockHeaderSummaryProto {
+    #[prost(message, optional, tag = "1")]
+    raw_data: Option<BlockHeaderRawSummaryProto>,
+}
+
+#[derive(Clone, Copy, PartialEq, Message)]
+struct BlockHeaderRawSummaryProto {
+    #[prost(int64, tag = "1")]
+    timestamp: i64,
+    #[prost(int64, tag = "7")]
+    number: i64,
+}
+
+#[derive(Clone, PartialEq, Message)]
+pub(super) struct BlockSummaryListProto {
+    #[prost(message, repeated, tag = "1")]
+    pub(super) blocks: Vec<BlockSummaryProto>,
+}
+
+impl BlockSummaryProto {
+    pub(super) fn into_block_info(
+        self,
+        fallback_hash: Option<B256>,
+    ) -> Result<BlockInfo, TransportErrorKind> {
+        let header = self
+            .block_header
+            .ok_or_else(|| TransportErrorKind::Malformed("missing block_header".into()))?;
+        let raw = header
+            .raw_data
+            .ok_or_else(|| TransportErrorKind::Malformed("missing block_header.raw_data".into()))?;
+
+        let hash = if self.block_id.is_empty() {
+            fallback_hash.ok_or_else(|| TransportErrorKind::Malformed("missing blockid".into()))?
+        } else {
+            let bytes = Bytes::from(self.block_id);
+            let block_id: [u8; 32] = bytes
+                .as_ref()
+                .try_into()
+                .map_err(|_| TransportErrorKind::Malformed("blockid must be 32 bytes".into()))?;
+            B256::from(block_id)
+        };
+
+        Ok(BlockInfo { number: raw.number, hash, timestamp: raw.timestamp })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto;
+
+    fn header(number: i64, timestamp: i64) -> proto::BlockHeader {
+        proto::BlockHeader {
+            raw_data: Some(proto::block_header::Raw {
+                number,
+                timestamp,
+                tx_trie_root: vec![1; 32],
+                parent_hash: vec![2; 32],
+                witness_address: vec![3; 21],
+                ..Default::default()
+            }),
+            witness_signature: vec![4; 65],
+        }
+    }
+
+    #[test]
+    fn decodes_extension_without_materializing_transactions() {
+        let full = proto::BlockExtention {
+            transactions: vec![proto::TransactionExtention {
+                txid: vec![5; 32],
+                constant_result: vec![vec![6; 1024].into()],
+                ..Default::default()
+            }],
+            block_header: Some(header(42, 1234)),
+            blockid: vec![7; 32],
+        };
+
+        let light = BlockSummaryProto::decode(full.encode_to_vec().as_slice()).unwrap();
+        let info = light.into_block_info(None).unwrap();
+
+        assert_eq!(info.number, 42);
+        assert_eq!(info.timestamp, 1234);
+        assert_eq!(info.hash, B256::from([7; 32]));
+    }
+
+    #[test]
+    fn plain_block_uses_requested_hash() {
+        let full = proto::Block {
+            transactions: vec![proto::Transaction::default()],
+            block_header: Some(header(9, 5678)),
+        };
+        let expected_hash = B256::from([8; 32]);
+
+        let light = BlockSummaryProto::decode(full.encode_to_vec().as_slice()).unwrap();
+        let info = light.into_block_info(Some(expected_hash)).unwrap();
+
+        assert_eq!(info.number, 9);
+        assert_eq!(info.timestamp, 5678);
+        assert_eq!(info.hash, expected_hash);
+    }
+}

--- a/crates/provider/src/transport/grpc/mod.rs
+++ b/crates/provider/src/transport/grpc/mod.rs
@@ -449,11 +449,11 @@ impl GrpcTransport {
 
     /// Check a `Return` message, converting failures to [`TransportErrorKind::NodeError`].
     fn check_return(ret: Option<proto::Return>) -> Result<(), TransportErrorKind> {
-        if let Some(r) = ret {
-            if !r.result {
-                let msg = String::from_utf8_lossy(&r.message).into_owned();
-                return Err(TransportErrorKind::NodeError(msg));
-            }
+        if let Some(r) = ret
+            && !r.result
+        {
+            let msg = String::from_utf8_lossy(&r.message).into_owned();
+            return Err(TransportErrorKind::NodeError(msg));
         }
         Ok(())
     }
@@ -491,7 +491,7 @@ fn signed_to_proto(tx: &SignedTransaction) -> Result<proto::Transaction, Transpo
 
 /// Decode a lowercase hex string into bytes using only the standard library.
 fn decode_hex(s: &str) -> Result<Vec<u8>, String> {
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err("odd number of hex digits".into());
     }
     s.as_bytes()

--- a/crates/provider/src/transport/grpc/mod.rs
+++ b/crates/provider/src/transport/grpc/mod.rs
@@ -3,13 +3,18 @@
 //! Default endpoint: `https://grpc.trongrid.io:443` (TronGrid mainnet, TLS).
 //! For local/private nodes use `http://127.0.0.1:50051` (no TLS).
 
+mod abi;
 mod codec;
+mod light_block;
 
 use std::{collections::HashMap, future::Future, time::Duration};
 
 use futures::future::try_join_all;
 use prost::Message as _;
 use tonic::{
+    GrpcMethod, Request,
+    client::Grpc,
+    codegen::http::uri::PathAndQuery,
     metadata::MetadataValue,
     service::Interceptor,
     transport::{Channel, Endpoint},
@@ -401,6 +406,47 @@ impl GrpcTransport {
         )
     }
 
+    /// Call a Wallet unary RPC using a custom wire-compatible response type.
+    ///
+    /// Generated clients fix the response type to the full TRON protobuf
+    /// message. Block-summary methods use this helper so prost can skip the
+    /// transaction payload instead of decoding data the public API discards.
+    async fn wallet_unary<Req, Res>(
+        &self,
+        req: Req,
+        path: &'static str,
+        method: &'static str,
+    ) -> Result<Res, TransportErrorKind>
+    where
+        Req: prost::Message + Default + Clone + Send + Sync + 'static,
+        Res: prost::Message + Default + Send + Sync + 'static,
+    {
+        self.call_with_retry(|| {
+            let service = tonic::codegen::InterceptedService::new(
+                self.channel.clone(),
+                ApiKeyInterceptor(self.api_key.clone()),
+            );
+            let req = req.clone();
+            async move {
+                let mut client = Grpc::new(service);
+                client.ready().await.map_err(|e| {
+                    TransportErrorKind::Grpc(tonic::Status::unknown(format!(
+                        "service was not ready: {}",
+                        e
+                    )))
+                })?;
+                let mut request = Request::new(req);
+                request.extensions_mut().insert(GrpcMethod::new("protocol.Wallet", method));
+                let codec = tonic_prost::ProstCodec::default();
+                Ok(client
+                    .unary(request, PathAndQuery::from_static(path), codec)
+                    .await?
+                    .into_inner())
+            }
+        })
+        .await
+    }
+
     /// Check a `Return` message, converting failures to [`TransportErrorKind::NodeError`].
     fn check_return(ret: Option<proto::Return>) -> Result<(), TransportErrorKind> {
         if let Some(r) = ret {
@@ -438,7 +484,7 @@ fn signed_to_proto(tx: &SignedTransaction) -> Result<proto::Transaction, Transpo
 
     let mut proto_tx = proto::Transaction::decode(tx.raw.raw_proto.as_ref())?;
     for sig in &tx.signatures {
-        proto_tx.signature.push(sig.to_bytes().to_vec());
+        proto_tx.signature.push(sig.to_bytes().to_vec().into());
     }
     Ok(proto_tx)
 }
@@ -498,14 +544,16 @@ impl TronTransport for GrpcTransport {
 
     async fn get_now_block(&self) -> Result<BlockInfo, Self::Error> {
         let req = EmptyMessage::default();
-        let ext = retry_unary!(self, wallet_client, get_now_block2, req)?;
-        codec::block_from_extention(ext)
+        let block: light_block::BlockSummaryProto =
+            self.wallet_unary(req, "/protocol.Wallet/GetNowBlock2", "GetNowBlock2").await?;
+        block.into_block_info(None)
     }
 
     async fn get_block_by_number(&self, num: i64) -> Result<BlockInfo, Self::Error> {
         let req = proto::NumberMessage { num };
-        let ext = retry_unary!(self, wallet_client, get_block_by_num2, req)?;
-        codec::block_from_extention(ext)
+        let block: light_block::BlockSummaryProto =
+            self.wallet_unary(req, "/protocol.Wallet/GetBlockByNum2", "GetBlockByNum2").await?;
+        block.into_block_info(None)
     }
 
     // --- Account ---
@@ -1131,14 +1179,17 @@ impl TronTransport for GrpcTransport {
 
     async fn get_block_by_id(&self, block_id: B256) -> Result<BlockInfo, Self::Error> {
         let req = proto::BytesMessage { value: block_id.as_slice().to_vec() };
-        let block = retry_unary!(self, wallet_client, get_block_by_id, req)?;
-        codec::block_from_plain(block)
+        let block: light_block::BlockSummaryProto =
+            self.wallet_unary(req, "/protocol.Wallet/GetBlockById", "GetBlockById").await?;
+        block.into_block_info(Some(block_id))
     }
 
     async fn get_blocks_by_latest_num(&self, count: i64) -> Result<Vec<BlockInfo>, Self::Error> {
         let req = proto::NumberMessage { num: count };
-        let list = retry_unary!(self, wallet_client, get_block_by_latest_num2, req)?;
-        list.block.into_iter().map(codec::block_from_extention).collect()
+        let list: light_block::BlockSummaryListProto = self
+            .wallet_unary(req, "/protocol.Wallet/GetBlockByLatestNum2", "GetBlockByLatestNum2")
+            .await?;
+        list.blocks.into_iter().map(|block| block.into_block_info(None)).collect()
     }
 
     async fn get_blocks_by_limit(
@@ -1147,8 +1198,10 @@ impl TronTransport for GrpcTransport {
         end: i64,
     ) -> Result<Vec<BlockInfo>, Self::Error> {
         let req = proto::BlockLimit { start_num: start, end_num: end };
-        let list = retry_unary!(self, wallet_client, get_block_by_limit_next2, req)?;
-        list.block.into_iter().map(codec::block_from_extention).collect()
+        let list: light_block::BlockSummaryListProto = self
+            .wallet_unary(req, "/protocol.Wallet/GetBlockByLimitNext2", "GetBlockByLimitNext2")
+            .await?;
+        list.blocks.into_iter().map(|block| block.into_block_info(None)).collect()
     }
 
     async fn get_transaction_count_by_block_num(&self, block_num: i64) -> Result<u64, Self::Error> {
@@ -1419,9 +1472,9 @@ impl TronTransport for GrpcTransport {
 
     async fn get_market_order_by_id(
         &self,
-        order_id: &[u8],
+        order_id: B256,
     ) -> Result<Option<MarketOrderInfo>, Self::Error> {
-        let req = proto::BytesMessage { value: order_id.to_vec() };
+        let req = proto::BytesMessage { value: order_id.as_slice().to_vec() };
         let order = retry_unary!(self, wallet_client, get_market_order_by_id, req)?;
         if order.order_id.is_empty() {
             return Ok(None);

--- a/crates/provider/src/transport/mock.rs
+++ b/crates/provider/src/transport/mock.rs
@@ -244,7 +244,7 @@ impl TronTransport for MockTransport {
         fn get_exchange_by_id(&self, exchange_id: i64) -> Option<ExchangeInfo>;
         fn market_sell_asset(&self, params: MarketSellAssetContract) -> RawTransaction;
         fn market_cancel_order(&self, params: MarketCancelOrderContract) -> RawTransaction;
-        fn get_market_order_by_id(&self, order_id: &[u8]) -> Option<MarketOrderInfo>;
+        fn get_market_order_by_id(&self, order_id: B256) -> Option<MarketOrderInfo>;
         fn get_market_order_by_account(&self, address: Address) -> Vec<MarketOrderInfo>;
         fn get_market_price_by_pair(&self, sell_token_id: &str, buy_token_id: &str) -> Vec<MarketPrice>;
         fn get_market_order_list_by_pair(&self, sell_token_id: &str, buy_token_id: &str) -> Vec<MarketOrderInfo>;

--- a/crates/provider/src/transport/mod.rs
+++ b/crates/provider/src/transport/mod.rs
@@ -659,7 +659,7 @@ pub trait TronTransport: Clone + Send + Sync + 'static + private::Sealed {
     /// Returns `None` if no order with that ID exists.
     fn get_market_order_by_id(
         &self,
-        order_id: &[u8],
+        order_id: B256,
     ) -> impl Future<Output = Result<Option<MarketOrderInfo>, Self::Error>> + Send;
 
     /// Fetch all market orders placed by `address`.

--- a/crates/provider/src/types/contract.rs
+++ b/crates/provider/src/types/contract.rs
@@ -2,7 +2,8 @@
 
 use std::collections::HashMap;
 
-use tronz_primitives::{Address, Bytes, ResourceCode, Trx};
+use tronz_abi::TronAbi;
+use tronz_primitives::{Address, B256, Bytes, ResourceCode, Trx};
 
 /// All TRON native contract types. Discriminants mirror the protobuf
 /// `Transaction.Contract.ContractType` enum.
@@ -294,8 +295,8 @@ pub struct CreateSmartContract {
     pub owner_address: Address,
     /// Contract bytecode.
     pub bytecode: Bytes,
-    /// JSON-encoded ABI.
-    pub abi: Vec<u8>,
+    /// Native TRON ABI metadata to store with the contract.
+    pub abi: TronAbi,
     /// TRX sent on deployment.
     pub call_value: Trx,
     /// Percentage of energy the caller (vs origin) pays.
@@ -679,14 +680,14 @@ pub struct MarketCancelOrderContract {
     /// Order owner address.
     pub owner_address: Address,
     /// The 32-byte order ID to cancel.
-    pub order_id: Vec<u8>,
+    pub order_id: B256,
 }
 
 /// Result of a constant (read-only) smart-contract call.
 #[derive(Clone, Debug, Default)]
 pub struct ConstantCallResult {
     /// Raw ABI-encoded return data.
-    pub output: Vec<u8>,
+    pub output: Bytes,
     /// Energy the call would have consumed.
     pub energy_used: i64,
     /// Revert message, if the call reverted.
@@ -856,8 +857,8 @@ pub struct SmartContractInfo {
     pub address: Option<Address>,
     /// Deployer address.
     pub origin_address: Option<Address>,
-    /// JSON-encoded ABI bytes.
-    pub abi: Vec<u8>,
+    /// Native TRON ABI metadata returned by the node.
+    pub abi: TronAbi,
     /// Creation bytecode (as supplied to `deploy_contract`).
     pub bytecode: Bytes,
     /// Deployed (runtime) bytecode — only populated by

--- a/crates/provider/src/types/market.rs
+++ b/crates/provider/src/types/market.rs
@@ -1,6 +1,6 @@
 //! Domain types for the TRON order-book DEX (Market Orders).
 
-use tronz_primitives::Address;
+use tronz_primitives::{Address, B256};
 
 /// State of a market order.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -18,7 +18,7 @@ pub enum MarketOrderState {
 #[non_exhaustive]
 pub struct MarketOrderInfo {
     /// Unique order ID (32-byte hash).
-    pub order_id: Vec<u8>,
+    pub order_id: B256,
     /// Address of the account that placed the order.
     pub owner_address: Address,
     /// Creation timestamp (unix ms).

--- a/crates/provider/src/types/mod.rs
+++ b/crates/provider/src/types/mod.rs
@@ -40,3 +40,6 @@ pub use network::{
 pub use receipt::{ContractResult, Log, ResourceReceipt, TransactionInfo, TxStatus};
 pub use transaction::{RawTransaction, SignedTransaction, TransactionRequest};
 pub use trc10::AssetInfo;
+pub use tronz_abi::{
+    TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiParam, TronAbiStateMutability,
+};

--- a/crates/provider/src/types/transaction.rs
+++ b/crates/provider/src/types/transaction.rs
@@ -157,10 +157,10 @@ impl RawTransaction {
             if let Some(memo) = &request.memo {
                 raw_data.data = memo.clone().into();
             }
-            if let Some(pid) = request.permission_id {
-                if let Some(contract) = raw_data.contract.first_mut() {
-                    contract.permission_id = pid;
-                }
+            if let Some(pid) = request.permission_id
+                && let Some(contract) = raw_data.contract.first_mut()
+            {
+                contract.permission_id = pid;
             }
             if let Some(bytes) = request.ref_block_bytes {
                 raw_data.ref_block_bytes = bytes.to_vec();

--- a/crates/provider/src/types/transaction.rs
+++ b/crates/provider/src/types/transaction.rs
@@ -2,7 +2,7 @@
 
 use std::time::Duration;
 
-use tronz_primitives::{RecoverableSignature, Trx, TxId};
+use tronz_primitives::{Bytes, RecoverableSignature, Trx, TxId};
 
 use crate::types::{BlockInfo, contract::ContractType};
 
@@ -15,7 +15,7 @@ pub struct TransactionRequest {
     /// Maximum fee (energy + bandwidth) the sender will pay.
     pub fee_limit: Option<Trx>,
     /// Optional memo / note (`raw.data`).
-    pub memo: Option<Vec<u8>>,
+    pub memo: Option<Bytes>,
     /// Permission id for multisig (`Contract.Permission_id`).
     pub permission_id: Option<i32>,
 
@@ -49,7 +49,7 @@ impl TransactionRequest {
     }
 
     /// Attach a memo / note.
-    pub fn with_memo(mut self, memo: impl Into<Vec<u8>>) -> Self {
+    pub fn with_memo(mut self, memo: impl Into<Bytes>) -> Self {
         self.memo = Some(memo.into());
         self
     }
@@ -94,14 +94,14 @@ pub struct RawTransaction {
     pub(crate) tx_id: TxId,
     /// Prost-encoded `Transaction` (no signatures yet). Used to build the
     /// broadcast message by appending signatures.
-    pub(crate) raw_proto: Vec<u8>,
+    pub(crate) raw_proto: Bytes,
 }
 
 impl RawTransaction {
     /// Construct from a `TransactionExtention` returned by the node.
     pub(crate) fn from_proto_extention(
         txid: Vec<u8>,
-        raw_proto: Vec<u8>,
+        raw_proto: impl Into<Bytes>,
         expiration: i64,
         timestamp: i64,
     ) -> Result<Self, crate::error::TransportErrorKind> {
@@ -111,7 +111,12 @@ impl RawTransaction {
             .try_into()
             .map_err(|_| TransportErrorKind::Malformed("txid must be 32 bytes".into()))?;
 
-        Ok(Self { expiration, timestamp, tx_id: TxId::from(tx_id_bytes), raw_proto })
+        Ok(Self {
+            expiration,
+            timestamp,
+            tx_id: TxId::from(tx_id_bytes),
+            raw_proto: raw_proto.into(),
+        })
     }
 
     /// The transaction id — `sha256` of the encoded `Transaction.raw`.
@@ -119,7 +124,7 @@ impl RawTransaction {
         self.tx_id
     }
 
-    /// Apply `fee_limit`, `memo`, and `permission_id` from a filled
+    /// Apply fee, memo, permission, and optional TAPOS overrides from a filled
     /// [`TransactionRequest`] to this raw transaction.
     ///
     /// When any field is set, the `Transaction.raw` proto bytes are decoded,
@@ -127,31 +132,53 @@ impl RawTransaction {
     /// recomputed so that the signature covers the updated payload.
     pub(crate) fn apply_request_fields(
         &mut self,
-        fee_limit_sun: Option<i64>,
-        memo: Option<&[u8]>,
-        permission_id: Option<i32>,
+        request: &TransactionRequest,
     ) -> Result<(), crate::error::TransportErrorKind> {
         use prost::Message as _;
         use sha2::{Digest, Sha256};
 
-        if fee_limit_sun.is_none() && memo.is_none() && permission_id.is_none() {
+        if request.fee_limit.is_none()
+            && request.memo.is_none()
+            && request.permission_id.is_none()
+            && request.ref_block_bytes.is_none()
+            && request.ref_block_hash.is_none()
+            && request.timestamp.is_none()
+            && request.expiration.is_none()
+        {
             return Ok(());
         }
 
         let mut tx = crate::proto::Transaction::decode(self.raw_proto.as_ref())?;
 
         if let Some(ref mut raw_data) = tx.raw_data {
-            if let Some(fl) = fee_limit_sun {
-                raw_data.fee_limit = fl;
+            if let Some(value) = request.fee_limit {
+                raw_data.fee_limit = value.as_sun();
             }
-            if let Some(m) = memo {
-                raw_data.data = m.to_vec();
+            if let Some(memo) = &request.memo {
+                raw_data.data = memo.clone().into();
             }
-            if let Some(pid) = permission_id {
+            if let Some(pid) = request.permission_id {
                 if let Some(contract) = raw_data.contract.first_mut() {
                     contract.permission_id = pid;
                 }
             }
+            if let Some(bytes) = request.ref_block_bytes {
+                raw_data.ref_block_bytes = bytes.to_vec();
+            }
+            if let Some(hash) = request.ref_block_hash {
+                raw_data.ref_block_hash = hash.to_vec();
+            }
+            if let Some(value) = request.timestamp {
+                raw_data.timestamp = value;
+            }
+            if let Some(value) = request.expiration {
+                raw_data.expiration = value;
+            }
+
+            // Keep the public metadata in sync with the protobuf payload that
+            // is signed and broadcast.
+            self.timestamp = raw_data.timestamp;
+            self.expiration = raw_data.expiration;
 
             // Recompute tx_id = sha256(encoded raw_data)
             let new_tx_id_bytes: [u8; 32] = Sha256::digest(raw_data.encode_to_vec()).into();
@@ -162,7 +189,7 @@ impl RawTransaction {
             ));
         }
 
-        self.raw_proto = tx.encode_to_vec();
+        self.raw_proto = tx.encode_to_vec().into();
         Ok(())
     }
 }
@@ -195,8 +222,50 @@ impl SignedTransaction {
             }
         };
         for sig in &self.signatures {
-            proto_tx.signature.push(sig.to_bytes().to_vec());
+            proto_tx.signature.push(sig.to_bytes().to_vec().into());
         }
         proto_tx.encoded_len() as u64
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use prost::Message as _;
+
+    use super::*;
+
+    #[test]
+    fn applies_explicit_tapos_fields_to_node_built_transaction() {
+        let tx = crate::proto::Transaction {
+            raw_data: Some(crate::proto::transaction::Raw {
+                timestamp: 1,
+                expiration: 2,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut raw =
+            RawTransaction::from_proto_extention(vec![0; 32], tx.encode_to_vec(), 2, 1).unwrap();
+
+        let request = TransactionRequest {
+            memo: Some(Bytes::from_static(b"memo")),
+            ref_block_bytes: Some([0xaa, 0xbb]),
+            ref_block_hash: Some([1, 2, 3, 4, 5, 6, 7, 8]),
+            timestamp: Some(10),
+            expiration: Some(20),
+            ..Default::default()
+        };
+        raw.apply_request_fields(&request).unwrap();
+
+        let decoded = crate::proto::Transaction::decode(raw.raw_proto.as_ref()).unwrap();
+        let data = decoded.raw_data.unwrap();
+        assert_eq!(data.ref_block_bytes, vec![0xaa, 0xbb]);
+        assert_eq!(data.ref_block_hash, vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        assert_eq!(data.data.as_ref(), b"memo");
+        assert_eq!(data.timestamp, 10);
+        assert_eq!(data.expiration, 20);
+        assert_eq!(raw.timestamp, 10);
+        assert_eq!(raw.expiration, 20);
+        assert_ne!(raw.tx_id(), TxId::from([0; 32]));
     }
 }

--- a/crates/sol-macro/src/lib.rs
+++ b/crates/sol-macro/src/lib.rs
@@ -286,10 +286,10 @@ impl TronSol {
 
         let mut rpc_contracts: Vec<&ItemContract> = Vec::new();
         for item in &self.items {
-            if let SolItem::Contract(c) = item {
-                if contract_opts(&c.attrs)?.rpc {
-                    rpc_contracts.push(c);
-                }
+            if let SolItem::Contract(c) = item
+                && contract_opts(&c.attrs)?.rpc
+            {
+                rpc_contracts.push(c);
             }
         }
 
@@ -709,29 +709,29 @@ fn strip_tron_attrs(ts: TokenStream2) -> TokenStream2 {
         }
 
         // Attribute: `#` [`!`] `[ ... ]`
-        if let TokenTree::Punct(p) = &tokens[i] {
-            if p.as_char() == '#' {
-                let mut j = i + 1;
-                let bang = matches!(tokens.get(j), Some(TokenTree::Punct(q)) if q.as_char() == '!');
-                if bang {
-                    j += 1;
-                }
-                if let Some(TokenTree::Group(g)) = tokens.get(j) {
-                    if g.delimiter() == Delimiter::Bracket {
-                        // `None` => drop the whole attribute (emit nothing).
-                        if let Some(inner) = rewrite_attr(g.stream()) {
-                            out.extend(once(tokens[i].clone()));
-                            if bang {
-                                out.extend(once(tokens[i + 1].clone()));
-                            }
-                            let mut ng = Group::new(Delimiter::Bracket, inner);
-                            ng.set_span(g.span());
-                            out.extend(once(TokenTree::Group(ng)));
-                        }
-                        i = j + 1;
-                        continue;
+        if let TokenTree::Punct(p) = &tokens[i]
+            && p.as_char() == '#'
+        {
+            let mut j = i + 1;
+            let bang = matches!(tokens.get(j), Some(TokenTree::Punct(q)) if q.as_char() == '!');
+            if bang {
+                j += 1;
+            }
+            if let Some(TokenTree::Group(g)) = tokens.get(j)
+                && g.delimiter() == Delimiter::Bracket
+            {
+                // `None` => drop the whole attribute (emit nothing).
+                if let Some(inner) = rewrite_attr(g.stream()) {
+                    out.extend(once(tokens[i].clone()));
+                    if bang {
+                        out.extend(once(tokens[i + 1].clone()));
                     }
+                    let mut ng = Group::new(Delimiter::Bracket, inner);
+                    ng.set_span(g.span());
+                    out.extend(once(TokenTree::Group(ng)));
                 }
+                i = j + 1;
+                continue;
             }
         }
 
@@ -757,16 +757,16 @@ fn rewrite_attr(inner: TokenStream2) -> Option<TokenStream2> {
         "tron_sol" => None,
         // `#[sol(...)]` — strip the TRON-only keys, keep the rest.
         "sol" => {
-            if let Some(TokenTree::Group(g)) = toks.get(1) {
-                if g.delimiter() == Delimiter::Parenthesis {
-                    let kept = filter_sol_meta(g.stream());
-                    if kept.is_empty() {
-                        return None;
-                    }
-                    let mut grp = Group::new(Delimiter::Parenthesis, kept);
-                    grp.set_span(g.span());
-                    return Some([toks[0].clone(), TokenTree::Group(grp)].into_iter().collect());
+            if let Some(TokenTree::Group(g)) = toks.get(1)
+                && g.delimiter() == Delimiter::Parenthesis
+            {
+                let kept = filter_sol_meta(g.stream());
+                if kept.is_empty() {
+                    return None;
                 }
+                let mut grp = Group::new(Delimiter::Parenthesis, kept);
+                grp.set_span(g.span());
+                return Some([toks[0].clone(), TokenTree::Group(grp)].into_iter().collect());
             }
             Some(inner)
         }
@@ -781,11 +781,11 @@ fn filter_sol_meta(stream: TokenStream2) -> TokenStream2 {
     // Split into comma-separated items (commas inside nested groups are atomic).
     let mut items: Vec<Vec<TokenTree>> = vec![Vec::new()];
     for tt in stream {
-        if let TokenTree::Punct(p) = &tt {
-            if p.as_char() == ',' {
-                items.push(Vec::new());
-                continue;
-            }
+        if let TokenTree::Punct(p) = &tt
+            && p.as_char() == ','
+        {
+            items.push(Vec::new());
+            continue;
         }
         items.last_mut().expect("non-empty").push(tt);
     }
@@ -969,7 +969,7 @@ fn parse_hex(lit: &LitStr) -> Result<Vec<u8>> {
     let span = lit.span();
     let s = lit.value();
     let s = s.strip_prefix("0x").or_else(|| s.strip_prefix("0X")).unwrap_or(&s);
-    if s.len() % 2 != 0 {
+    if !s.len().is_multiple_of(2) {
         return Err(syn::Error::new(span, "bytecode hex string has odd length"));
     }
     s.as_bytes()

--- a/crates/tronz/Cargo.toml
+++ b/crates/tronz/Cargo.toml
@@ -12,6 +12,7 @@ readme       = { workspace = true }
 
 [dependencies]
 tronz-primitives = { workspace = true }
+tronz-abi        = { workspace = true }
 tronz-signer     = { workspace = true }
 tronz-provider   = { workspace = true }
 tronz-contract   = { workspace = true, optional = true, features = ["provider"] }
@@ -34,4 +35,3 @@ signer-mnemonic = ["tronz-signer/mnemonic"]
 signer-keystore = ["tronz-signer/keystore"]
 # AWS KMS signer (private key stays in the HSM).
 signer-aws = ["dep:tronz-signer-aws"]
-

--- a/crates/tronz/README.md
+++ b/crates/tronz/README.md
@@ -72,6 +72,7 @@ For more examples, see the [`examples/`](https://github.com/throgxyz/tronz/tree/
 | Crate | Description |
 |-------|-------------|
 | [`tronz`] | Meta-crate re-exporting all sub-crates |
+| [`tronz-abi`] | Native TRON ABI metadata and optional Alloy JSON ABI conversion |
 | [`tronz-primitives`] | `Address`, `Trx`, `ResourceCode`, signatures |
 | [`tronz-signer`] | `TronSigner` trait and `LocalSigner` implementation |
 | [`tronz-provider`] | Transport, provider, fillers, and domain types |
@@ -79,6 +80,7 @@ For more examples, see the [`examples/`](https://github.com/throgxyz/tronz/tree/
 | [`tronz-signer-aws`] | AWS KMS signer (`signer-aws` feature) |
 
 [`tronz`]: https://github.com/throgxyz/tronz/tree/main/crates/tronz
+[`tronz-abi`]: https://github.com/throgxyz/tronz/tree/main/crates/abi
 [`tronz-primitives`]: https://github.com/throgxyz/tronz/tree/main/crates/primitives
 [`tronz-signer`]: https://github.com/throgxyz/tronz/tree/main/crates/signer
 [`tronz-provider`]: https://github.com/throgxyz/tronz/tree/main/crates/provider
@@ -87,7 +89,7 @@ For more examples, see the [`examples/`](https://github.com/throgxyz/tronz/tree/
 
 ## Supported Rust Versions (MSRV)
 
-The minimum supported Rust version is **1.85**.
+The minimum supported Rust version is **1.91.1**.
 
 ## Contributing
 

--- a/crates/tronz/src/lib.rs
+++ b/crates/tronz/src/lib.rs
@@ -12,6 +12,19 @@ pub use primitives::{Address, ResourceCode, Trx, U256, format_trx, parse_trx};
 #[doc(inline)]
 pub use tronz_primitives as primitives;
 
+/* ------------------------------------ ABI ------------------------------------- */
+
+/// Native TRON smart-contract ABI metadata types.
+pub mod abi {
+    #[doc(inline)]
+    pub use tronz_abi::*;
+}
+
+#[doc(no_inline)]
+pub use tronz_abi::{
+    TronAbi, TronAbiEntry, TronAbiEntryType, TronAbiParam, TronAbiStateMutability,
+};
+
 /* ---------------------------------- Signers ----------------------------------- */
 
 /// TRON signer abstraction and local key implementation.
@@ -76,3 +89,7 @@ pub mod contract {
     #[doc(inline)]
     pub use tronz_contract::*;
 }
+
+#[cfg(feature = "contract")]
+#[doc(no_inline)]
+pub use tronz_contract::JsonAbi;


### PR DESCRIPTION
## Summary

- Add native TRON ABI support and Alloy `JsonAbi` conversion.
- Reduce protobuf decoding and memory allocation overhead.
- Improve TAPOS handling and block-range queries.
- Raise MSRV to Rust 1.91.1.

## Validation

- Tests, clippy, rustdoc, and feature checks pass.